### PR TITLE
Added description, how to install fastcdr on linux

### DIFF
--- a/docs/sources.rst
+++ b/docs/sources.rst
@@ -13,6 +13,14 @@ If you are on Linux, execute: ::
     $ cmake -DTHIRDPARTY=ON ..
     $ make
     $ sudo make install
+    
+In addition, the installation of the cdr library is needed: ::
+
+    $ cd ../thirdparty/fastcdr/
+    $ mkdir build && cd build
+    $ cmake ..
+    $ make
+    $ sudo make install
 
 If you are on Windows, choose your version of Visual Studio: ::
 


### PR DESCRIPTION
Perhaps there is a better way to install the libraries, but this approach works. And they are needed for running the examples.