### PR TITLE
Refs #6341 Adapted documentation to the Fast-RTPS-Gen emancipation. [6353]

### DIFF
--- a/docs/geninfo.rst
+++ b/docs/geninfo.rst
@@ -35,7 +35,7 @@ In order to compile *fastrtpsgen* you first need to have `gradle <https://gradle
 `java JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ installed
 (please, check the JDK recommended version for the gradle version you have installed).
 
-If you want to compile *fastrtpsgen* java application, you will need to download its source code from
+To compile *fastrtpsgen* java application, you will need to download its source code from
 the `Fast-RPTS-Gen <https://github.com/eProsima/Fast-RTPS-Gen>`_ repository and with ``--recursive`` option and
 compile it calling ``gradle assemble``. For more details see :ref:`compile-fastrtpsgen`.
 

--- a/docs/geninfo.rst
+++ b/docs/geninfo.rst
@@ -31,6 +31,20 @@ It also provides an initial implementation of a publisher and a subscriber using
 Compile
 -------
 
-In order to compile *fastrtpsgen* you first need to have `gradle <https://gradle.org/install>`_ and `java JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ installed (please, check the JDK recommended version for the gradle version you have installed).
+In order to compile *fastrtpsgen* you first need to have `gradle <https://gradle.org/install>`_ and
+`java JDK <http://www.oracle.com/technetwork/java/javase/downloads/index.html>`_ installed
+(please, check the JDK recommended version for the gradle version you have installed).
 
-To generate *fastrtpsgen* you will need to add the argument ``-DBUILD_JAVA=ON`` when calling CMake.
+If you want to compile *fastrtpsgen* java application, you will need to download its source code from
+the `Fast-RPTS-Gen <https://github.com/eProsima/Fast-RTPS-Gen>`_ repository and with ``--recursive`` option and
+compile it calling ``gradle assemble``. For more details see :ref:`compile-fastrtpsgen`.
+
+.. code-block:: bash
+
+    > git clone --recursive https://github.com/eProsima/Fast-RTPS-Gen.git
+    > cd Fast-RTPS-Gen
+    > gradle assemble
+
+The generated java application can be found at ``share/fastrtps`` and more user friendly scripts at ``scripts`` folders.
+If you want to make these scripts available from anywhere you can add the ``scripts`` folder path to your ``PATH``
+environment variable.

--- a/docs/genuse.rst
+++ b/docs/genuse.rst
@@ -5,10 +5,13 @@ Building publisher/subscriber code
 ----------------------------------
 This section guides you through the usage of this Java application and briefly describes the generated files.
 
-The Java application can be executed using the following scripts depending on if you are on Windows or Linux: ::
+Once you added ``scripts`` folder to your ``PATH``,
+the Java application can be executed using the following scripts depending on if you are on Windows or Linux: ::
 
     > fastrtpsgen.bat
     $ fastrtpsgen
+
+In case you didn't modified your ``PATH`` you can find these scripts in your ``<fastrtpsgen_directory>/scripts`` folder.
 
 The expected argument list of the application is: ::
 

--- a/docs/sources.rst
+++ b/docs/sources.rst
@@ -89,15 +89,20 @@ Once all dependencies are installed, you will be able to compile and install Fas
    $ cmake ..
    $ cmake --build . --target install
 
-If you want to compile *fastrtpsgen* java application, you will need to add the argument ``-DBUILD_JAVA=ON`` when
-calling CMake (see :ref:`compile-fastrtpsgen`).
-
 If you want to compile the examples, you will need to add the argument ``-DCOMPILE_EXAMPLES=ON`` when calling CMake.
 
 If you want to compile the performance tests, you will need to add the argument ``-DPERFORMANCE_TESTS=ON`` when calling
 CMake.
 
 For generate *fastrtpsgen* please see :ref:`compile-fastrtpsgen`.
+
+Fast-RTPS-gen
+*************
+
+If you want to compile *fastrtpsgen* java application, you will need to download its source code from
+the `Fast-RPTS-Gen <https://github.com/eProsima/Fast-RTPS-Gen>`_ repository and with ``--recursive`` option and
+compile it calling ``gradle assemble``. For more details see :ref:`compile-fastrtpsgen`.
+
 
 Security
 ********


### PR DESCRIPTION
Fast-RTPS-Gen is not going to be directly available within Fast-RTPS and will need a separate build process.