### PR TITLE
Feature/intra process

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1006,6 +1006,8 @@
 
         <discoveryProtocol>NONE</discoveryProtocol> <!-- DiscoveryProtocol enum -->
 
+        <ignoreParticipantFlags></ignoreParticipantFlags> <!-- ParticipantFlags enum -->
+
         <EDP>SIMPLE</EDP>  <!-- string -->
 
         <leaseDuration>
@@ -2030,6 +2032,11 @@
 
         <entityID>66</entityID>
     </subscriber>
+
+<!-->CONF-LIBRARY-SETTINGS<-->
+    <library_settings>
+        <intraprocess_delivery>FULL</intraprocess_deliveray> <!-- OFF | USER_DATA_ONLY | FULL -->
+    </library_settings>
 </profiles>
 <!--><-->
 
@@ -2049,3 +2056,6 @@
     </consumer>
 </log>
 <!--><-->
+
+
+

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1006,7 +1006,7 @@
 
         <discoveryProtocol>NONE</discoveryProtocol> <!-- DiscoveryProtocol enum -->
 
-        <ignoreParticipantFlags></ignoreParticipantFlags> <!-- ParticipantFlags enum -->
+        <ignoreParticipantFlags>FILTER_DIFFERENT_HOST</ignoreParticipantFlags> <!-- ParticipantFlags enum -->
 
         <EDP>SIMPLE</EDP>  <!-- string -->
 
@@ -2035,9 +2035,8 @@
 
 <!-->CONF-LIBRARY-SETTINGS<-->
     <library_settings>
-        <intraprocess_delivery>FULL</intraprocess_deliveray> <!-- OFF | USER_DATA_ONLY | FULL -->
+        <intraprocess_delivery>FULL</intraprocess_delivery> <!-- OFF | USER_DATA_ONLY | FULL -->
     </library_settings>
-</profiles>
 <!--><-->
 
 <!-->LOG-CONFIG<-->
@@ -2058,4 +2057,4 @@
 <!--><-->
 
 
-
+</profiles>

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -58,6 +58,19 @@ This consist of defining a maximum number of data sinks and a maximum size for e
 Note that your History must be big enough to accommodate the maximum number of samples for each key.
 eProsima Fast RTPS will notify you if your History is too small.
 
+.. _intraprocess-delivery
+
+Intraprocess delivery
+*********************
+
+*eProsima Fast RTPS* allows to speed up intraprocess communications by avoiding any copy operation involved with
+the transport layer. This feature is disable by default and must be enable using :ref:`xml-profiles`. Currently the
+following options are available:
+
+**INTRAPROCESS_OFF**. Default value, the feature is disabled.
+**INTRAPROCESS_USER_DATA_ONLY**. Discovery metratraffic keeps using ordinary transport.
+**INTRAPROCESS_FULL**. Discovery metatraffic avoids using ordinary transport.
+
 .. _comm-transports-configuration:
 
 Transports
@@ -690,6 +703,13 @@ DiscoverySettings
  |    :start-after: <!-->CONF-QOS-DISABLE-DISCOVERY |
  |    :end-before: <!--><-->                        |
  +--------------------------------------------------+
+
++ a **ignoreParticipantFlags** member specifies participant filtering criteria to optimize discovery stage speed and memory usage. This feature is only available for the `SIMPLE` discovery protocol. There are several options:
+
+ * **FILTER_DIFFERENT_HOST** all metadata from another host, implying a different local network address, would be discarded.
+ * **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
+ * **FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
+ * **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.
 
 + **use_XXX_EndpointDiscoveryProtocol** flags. There is a specific section dealing with them
   (see `Static Endpoints Discovery`_).

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -60,16 +60,16 @@ eProsima Fast RTPS will notify you if your History is too small.
 
 .. _intraprocess-delivery:
 
-Intraprocess delivery
-*********************
+Intra-process delivery
+**********************
 
-*eProsima Fast RTPS* allows to speed up intraprocess communications by avoiding any copy operation involved with
+*eProsima Fast RTPS* allows to speed up Intra-process communications by avoiding any copy operation involved with
 the transport layer. This feature is disabled by default and must be enable using :ref:`xml-profiles`. Currently the
 following options are available:
 
-**INTRAPROCESS_OFF**. Default value, the feature is disabled.
-**INTRAPROCESS_USER_DATA_ONLY**. Discovery metratraffic keeps using ordinary transport.
-**INTRAPROCESS_FULL**. Discovery metatraffic avoids using ordinary transport.
+* **INTRAPROCESS_OFF**. Default value, the feature is disabled.
+* **INTRAPROCESS_USER_DATA_ONLY**. Discovery metadata keeps using ordinary transport.
+* **INTRAPROCESS_FULL**. Both user data and discovery metadata using Intra-process delivery.
 
 .. _comm-transports-configuration:
 
@@ -710,7 +710,7 @@ DiscoverySettings
  * **FILTER_DIFFERENT_HOST** all metadata from another host would be discarded.
  * **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
  * **FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
- * **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.
+ * **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metadata from our own host would be discarded.
 
 + **use_XXX_EndpointDiscoveryProtocol** flags. There is a specific section dealing with them
   (see `Static Endpoints Discovery`_).

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -58,13 +58,13 @@ This consist of defining a maximum number of data sinks and a maximum size for e
 Note that your History must be big enough to accommodate the maximum number of samples for each key.
 eProsima Fast RTPS will notify you if your History is too small.
 
-.. _intraprocess-delivery
+.. _intraprocess-delivery:
 
 Intraprocess delivery
 *********************
 
 *eProsima Fast RTPS* allows to speed up intraprocess communications by avoiding any copy operation involved with
-the transport layer. This feature is disable by default and must be enable using :ref:`xml-profiles`. Currently the
+the transport layer. This feature is disabled by default and must be enable using :ref:`xml-profiles`. Currently the
 following options are available:
 
 **INTRAPROCESS_OFF**. Default value, the feature is disabled.
@@ -704,9 +704,10 @@ DiscoverySettings
  |    :end-before: <!--><-->                        |
  +--------------------------------------------------+
 
-+ a **ignoreParticipantFlags** member specifies participant filtering criteria to optimize discovery stage speed and memory usage. This feature is only available for the `SIMPLE` discovery protocol. There are several options:
++ a **ignoreParticipantFlags** member specifies participant filtering criteria to optimize discovery stage speed
+and memory usage. This feature is only available for the `SIMPLE` discovery protocol. There are several options:
 
- * **FILTER_DIFFERENT_HOST** all metadata from another host, implying a different local network address, would be discarded.
+ * **FILTER_DIFFERENT_HOST** all metadata from another host would be discarded.
  * **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
  * **FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
  * **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -705,7 +705,7 @@ DiscoverySettings
  +--------------------------------------------------+
 
 + a **ignoreParticipantFlags** member specifies participant filtering criteria to optimize discovery stage speed
-and memory usage. This feature is only available for the `SIMPLE` discovery protocol. There are several options:
+  and memory usage. This feature is only available for the `SIMPLE` discovery protocol. There are several options:
 
  * **FILTER_DIFFERENT_HOST** all metadata from another host would be discarded.
  * **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.

--- a/docs/xmlprofiles.rst
+++ b/docs/xmlprofiles.rst
@@ -842,7 +842,7 @@ This section of the :class:`Participant's rtps` configuration allows defining bu
 
 **ignoreParticipantFlags**
 
-**FILTER_DIFFERENT_HOST** all metadata from another host, implying a different local network address, would be discarded.
+**FILTER_DIFFERENT_HOST** all metadata from another host would be discarded.
 **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
 **FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
 **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.

--- a/docs/xmlprofiles.rst
+++ b/docs/xmlprofiles.rst
@@ -753,7 +753,7 @@ This section of the :class:`Participant's rtps` configuration allows defining bu
 .. |writhistmem| replace:: ``<writerHistoryMemoryPolicy>``
 .. |mutTries| replace:: ``<mutation_tries>``
 .. |igpartf| replace:: ``<ignoreParticipantFlags>``
-.. |filterlist| replace:: Enum of :ref:`Participantfiltering`
+.. |filterlist| replace:: :ref:`ignoreParticipantFlags <Participantfiltering>`
 
 +--------------------------------+----------------------------------+-------------------------+-----------------------+
 | Name                           | Description                      | Values                  | Default               |
@@ -842,10 +842,10 @@ This section of the :class:`Participant's rtps` configuration allows defining bu
 
 **ignoreParticipantFlags**
 
-**FILTER_DIFFERENT_HOST** all metadata from another host would be discarded.
-**FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
-**FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
-**FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.
+* **FILTER_DIFFERENT_HOST** all metadata from another host would be discarded.
+* **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
+* **FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
+* **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metadata from our own host would be discarded.
 
 .. _sedp:
 

--- a/docs/xmlprofiles.rst
+++ b/docs/xmlprofiles.rst
@@ -61,7 +61,7 @@ Library settings
 -----------------
 
 This section is devoted to general settings that are not constraint to specific entities
- (like participants, subscribers, publishers) or functionality (like transports or types). All of them
+(like participants, subscribers, publishers) or functionality (like transports or types). All of them
 are gathered under the ``library_settings`` profile.
 
 .. literalinclude:: ../code/XMLTester.xml

--- a/docs/xmlprofiles.rst
+++ b/docs/xmlprofiles.rst
@@ -55,6 +55,22 @@ this profile name and applies the XML profile to the entity.
 
 To load dynamic types from its declaration through XML see the :ref:`Usage` section of :ref:`xmldynamictypes`.
 
+.. _librarySettingsAttributes:
+
+Library settings
+-----------------
+
+This section is devoted to general settings that are not constraint to specific entities
+ (like participants, subscribers, publishers) or functionality (like transports or types). All of them
+are gathered under the ``library_settings`` profile.
+
+.. literalinclude:: ../code/XMLTester.xml
+    :language: xml
+    :start-after: <!-->CONF-LIBRARY-SETTINGS<-->
+    :end-before: <!--><-->
+
+Currently only the :ref:`intraprocess-delivery` feature is comprised here.
+
 .. _transportdescriptors:
 
 Transport descriptors
@@ -736,6 +752,8 @@ This section of the :class:`Participant's rtps` configuration allows defining bu
 .. |readhistmem| replace:: ``<readerHistoryMemoryPolicy>``
 .. |writhistmem| replace:: ``<writerHistoryMemoryPolicy>``
 .. |mutTries| replace:: ``<mutation_tries>``
+.. |igpartf| replace:: ``<ignoreParticipantFlags>``
+.. |filterlist| replace:: Enum of :ref:`Participantfiltering`
 
 +--------------------------------+----------------------------------+-------------------------+-----------------------+
 | Name                           | Description                      | Values                  | Default               |
@@ -743,6 +761,9 @@ This section of the :class:`Participant's rtps` configuration allows defining bu
 | ``<discovery_config>``         | This is the main tag where       |                         |                       |
 |                                | discovery-related settings can   | :ref:`discovery_config  |                       |
 |                                | be configured.                   | <dconf>`                |                       |
++--------------------------------+----------------------------------+-------------------------+-----------------------+
+| |igpartf|                      | Restricts metatraffic using      | |filterlist|            | No filtering.         |
+|                                | several filtering criteria.      |                         |                       |
 +--------------------------------+----------------------------------+-------------------------+-----------------------+
 | ``<avoid_builtin_multicast>``  | Restricts metatraffic multicast  | ``Boolean``             | :class:`true`         |
 |                                | traffic to PDP only.             |                         |                       |
@@ -816,6 +837,15 @@ This section of the :class:`Participant's rtps` configuration allows defining bu
 |                            | Only necessary if ``<EDP>``           |                         |                      |
 |                            | is set to :class:`STATIC`             |                         |                      |
 +----------------------------+---------------------------------------+-------------------------+----------------------+
+
+.. _Participantfiltering:
+
+**ignoreParticipantFlags**
+
+**FILTER_DIFFERENT_HOST** all metadata from another host, implying a different local network address, would be discarded.
+**FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
+**FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
+**FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.
 
 .. _sedp:
 


### PR DESCRIPTION
Updating **xml profiles** to include intraprocess set up:

* **INTRAPROCESS_OFF**. Default value, the feature is disabled.
* **INTRAPROCESS_USER_DATA_ONLY**. Discovery metratraffic keeps using ordinary transport.
* **INTRAPROCESS_FULL**. Discovery metatraffic avoids using ordinary transport.

Updating `discovery settings` to include new participant filtering capabilities.
* **FILTER_DIFFERENT_HOST** all metadata from another host, implying a different local network address, would be discarded.
* **FILTER_DIFFERENT_PROCESS** all metadata from another process on the same host would be discarded.
* **FILTER_SAME_PROCESS** all metadata from our own process would be discarded.
* **FILTER_DIFFERENT_PROCESS | FILTER_SAME_PROCESS** all metada from our own host would be discarded.
