### PR TITLE
Fixing position of <log> tag

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -2039,6 +2039,8 @@
     </library_settings>
 <!--><-->
 
+</profiles>
+
 <!-->LOG-CONFIG<-->
 <log>
     <use_default>FALSE</use_default>
@@ -2057,4 +2059,3 @@
 <!--><-->
 
 
-</profiles>


### PR DESCRIPTION
PRs against 1.9.x are failing because the `log` tag on `XMLTester.xml` is inside the `<profiles>` tag, and it should be in the root of the xml.