### PR TITLE
Documentation of variable length submessage limits [7413]

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -165,7 +165,7 @@ participant_attr.rtps.allocation.participants = eprosima::fastrtps::ResourceLimi
 participant_attr.rtps.allocation.readers = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
 // We know we have at most 1 writer on each participant
 participant_attr.rtps.allocation.writers = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
-// We know the maximum size of partitiondata
+// We know the maximum size of partition data
 participant_attr.rtps.allocation.data_limits.max_partitions = 256u;
 // We know the maximum size of user data
 participant_attr.rtps.allocation.data_limits.max_user_data = 256u;

--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -165,6 +165,12 @@ participant_attr.rtps.allocation.participants = eprosima::fastrtps::ResourceLimi
 participant_attr.rtps.allocation.readers = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(2u);
 // We know we have at most 1 writer on each participant
 participant_attr.rtps.allocation.writers = eprosima::fastrtps::ResourceLimitedContainerConfig::fixed_size_configuration(1u);
+// We know the maximum size of partitiondata
+participant_attr.rtps.allocation.data_limits.max_partitions = 256u;
+// We know the maximum size of user data
+participant_attr.rtps.allocation.data_limits.max_user_data = 256u;
+// We know the maximum size of properties data
+participant_attr.rtps.allocation.data_limits.max_properties = 512u;
 
 // Before creating the publisher for topic 1:
 // we know we will only have three matching subscribers

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -993,6 +993,9 @@
         <maximum>0</maximum>
         <increment>1</increment>
     </total_writers>
+    <max_partitions>256</max_partitions>
+    <max_user_data>256</max_user_data>
+    <max_properties>512</max_properties>
 </allocation>
 <!--><-->
 </rtps>
@@ -1387,6 +1390,9 @@
                 <maximum>1</maximum>
                 <increment>0</increment>
             </total_writers>
+            <max_partitions>256</max_partitions>
+            <max_user_data>256</max_user_data>
+            <max_properties>512</max_properties>
         </allocation>
     </rtps>
 </participant>

--- a/docs/realtime.rst
+++ b/docs/realtime.rst
@@ -62,6 +62,22 @@ The user can specify the :class:`initial` number of elements preallocated, the :
 allowed, and the allocation :class:`increment`.
 By default, a full dynamic behavior is used.
 
+Limiting the size of parameters
+-------------------------------
+
+Most of the information held for participants and endpoints have a defined size limit, so the amount of memory to
+allocate for each local and remote peer is known. But some of the parameters have no limit on size, and depend on
+the configuration. :class:`RTPSParticipantAllocationAttributes` has a field :class:`data_limits` to set maximum
+sizes to these parameters:
+
+* :class:`max_partitions` limits the size of partition data to the given number in octets.
+* :class:`max_user_data` limits the size of user data to the given number in octets.
+* :class:`max_properties` limits the size of participant properties data to the given number in octets.
+
+A value of zero implies no size limitation. If these sizes are configured and not zero, enough memory
+will be allocated for them for each participant and endpoint. If these sizes are not limited, memory
+will be dynamically allocated as needed. By default, a full dynamic behavior is used.
+
 Parameters on the publisher
 ===========================
 
@@ -108,6 +124,12 @@ Given a system with the following topology:
 * The publisher for topic 1 matches with 3 subscribers, and the publisher for topic 2 matches with 2 subscribers.
 * The maximum number of publishers per participant is 1, and the maximum number of subscribers per participant is 2.
 * The total number of participants is 3.
+
+We will also limit the size of the parameters:
+
+* Maximum partition data size: 256
+* Maximum user data size: 256
+* Maximum properties data size: 512
 
 The following piece of code shows the set of parameters needed for the use case depicted in this example.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -77,6 +77,7 @@ stateful
 Structs
 structs
 subfolder
+submessage
 submessages
 submodules
 takeNextData

--- a/docs/xmlprofiles.rst
+++ b/docs/xmlprofiles.rst
@@ -730,6 +730,18 @@ behavior on the participant.
      - Participant :ref:`CommonAlloc` related to the total number of writers on each participant (local and remote).
      - :ref:`CommonAlloc`
      -
+   * - ``<max_partitions>``
+     - Maximum size of the partitions submessage or zero for no limit. See :ref:`MessageMaxSize`.
+     - ``UInt32``
+     -
+   * - ``<max_user_data>``
+     - Maximum size of the user data submessage or zero for no limit. See :ref:`MessageMaxSize`.
+     - ``UInt32``
+     -
+   * - ``<max_properties>``
+     - Maximum size of the properties submessage or zero for no limit. See :ref:`MessageMaxSize`.
+     - ``UInt32``
+     -
 
 .. _builtin:
 
@@ -1414,7 +1426,27 @@ See :ref:`realtime-allocations` for detailed information on how to tune allocati
      - ``UInt32``
      - 1
 
+.. _MessageMaxSize:
+
+Submessage Size Limit
+^^^^^^^^^^^^^^^^^^^^^
+
+While some submessages have a fixed size (for example, SequenceNumber), others have a variable size depending
+on the data they contain.
+
+Processing a submessage requires having a memory chunk large enough to contain a copy of its data.
+That's easy with fixed variable submessages, as size is known and memory can be allocated beforehand.
+For variable size submessages we can use two strategies:
+
+    - Set a maximum size for the data container, that will be allocated beforehand during the setup of
+      the participant. This avoids dynamic allocations during message communication, but any submessage
+      with a larger payload than the defined maximum will not fit in, and will be discarded.
+    - So not set any maximum and allocate the required memory dinamically upon submessage arrival,
+      according to the size declared on the header. This allows any size of submessages at the cost of
+      dynamic allocations during message decoding.
+
 .. _mempol:
+
 
 History Memory Policy Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/xmlprofiles.rst
+++ b/docs/xmlprofiles.rst
@@ -1441,7 +1441,7 @@ For variable size submessages we can use two strategies:
     - Set a maximum size for the data container, that will be allocated beforehand during the setup of
       the participant. This avoids dynamic allocations during message communication, but any submessage
       with a larger payload than the defined maximum will not fit in, and will be discarded.
-    - So not set any maximum and allocate the required memory dinamically upon submessage arrival,
+    - Do not set any maximum and allocate the required memory dynamically upon submessage arrival,
       according to the size declared on the header. This allows any size of submessages at the cost of
       dynamic allocations during message decoding.
 


### PR DESCRIPTION
Describes how to limit the size of variable length submessages: Partition, Userdata and Properties

DO NOT MERGE UNTIL THE CODE IS MERGED TOO