### PR TITLE
Add API-REF in READ THE DOCS [8473]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ html:
 	mkdir -p build/code
 	cd build/code && cmake ../../code -DBUILDCOP=OFF
 	cmake --build build/code
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
@@ -68,7 +67,7 @@ compile:
 	@echo "Source code build finished."
 
 .PHONY: test
-test: html compile
+test: compile
 	doc8 --max-line-length 120 docs
 	@echo
 	@echo "RST checking finished."

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -133,19 +133,48 @@ add_custom_target(doc-dirs
 
 # Get header files from repo instead of from installation. This way Fast RTPS does not need to be compiled
 file(GLOB_RECURSE HPP_FILES "${PROJECT_BINARY_DIR}/external/eprosima/src/fastrtps/include/fastdds/**/*.h*")
-set(INCLUDE_FILE "${PROJECT_BINARY_DIR}/external/eprosima/src/fastrtps/include/fastdds")
+
+# Doxygen related variables
+set(DOXYGEN_INPUT_DIR "${PROJECT_BINARY_DIR}/external/eprosima/src/fastrtps/include/fastdds")
+set(DOXYGEN_OUTPUT_DIR "${PROJECT_BINARY_DIR}/doxygen")
+set(DOXYGEN_INDEX_FILE "${PROJECT_BINARY_DIR}/doxygen/xml/index.xml")
+set(DOXYFILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/doxygen-config.in")
+set(DOXYFILE_OUT ${PROJECT_BINARY_DIR}/doxygen-config)
 
 # Configure doxygen
-configure_file(doxygen-config.in ${PROJECT_BINARY_DIR}/doxygen-config @ONLY)
-add_custom_command(OUTPUT "${PROJECT_BINARY_DIR}/doxygen/xml/index.xml"
-    COMMAND "${DOXYGEN_EXECUTABLE}" "${PROJECT_BINARY_DIR}/doxygen-config"
+configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+
+# Doxygen command
+add_custom_command(OUTPUT ${DOXYGEN_INDEX_FILE}
+    COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
     DEPENDS ${HPP_FILES}
-    )
+    MAIN_DEPENDENCY ${DOXYFILE_OUT} ${DOXYFILE_IN}
+    COMMENT "Generating doxygen documentation")
+
 # Generate API reference
 add_custom_target(doxygen ALL
-    DEPENDS "${PROJECT_BINARY_DIR}/doxygen/xml/index.xml"
+    DEPENDS ${DOXYGEN_INDEX_FILE}
     COMMENT "Generated API documentation with doxygen" VERBATIM)
 add_dependencies(doxygen doc-dirs)
+
+########################################################################################################################
+# Build Sphinx documentation
+########################################################################################################################
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+find_package(Sphinx REQUIRED)
+
+set(SPHINX_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/../docs")
+set(SPHINX_BUILD "${PROJECT_BINARY_DIR}/../html")
+
+add_custom_target(Sphinx ALL
+                  COMMAND
+                  ${SPHINX_EXECUTABLE} -b html
+                  # Tell Breathe where to find the Doxygen output
+                  -Dbreathe_projects.FastDDS=${DOXYGEN_OUTPUT_DIR}/xml
+                  -d "${PROJECT_BINARY_DIR}/../doctrees" ${SPHINX_SOURCE} ${SPHINX_BUILD}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                  DEPENDS doxygen
+                  COMMENT "Generating documentation with Sphinx")
 
 ########################################################################################################################
 # Build example and tests

--- a/code/cmake/FindSphinx.cmake
+++ b/code/cmake/FindSphinx.cmake
@@ -1,0 +1,11 @@
+# Look for an executable called sphinx-build
+find_program(SPHINX_EXECUTABLE
+             NAMES sphinx-build
+             DOC "Path to sphinx-build executable")
+
+include(FindPackageHandleStandardArgs)
+
+# Handle standard arguments to find_package like REQUIRED and QUIET
+find_package_handle_standard_args(Sphinx
+                                  "Failed to find sphinx-build executable"
+                                  SPHINX_EXECUTABLE)

--- a/code/doxygen-config.in
+++ b/code/doxygen-config.in
@@ -8,11 +8,10 @@ PROJECT_NAME           = "Fast RTPS Docs"
 PROJECT_NUMBER         = "TODO"
 PROJECT_BRIEF          =
 PROJECT_LOGO           =
-OUTPUT_DIRECTORY       = "@PROJECT_BINARY_DIR@/doxygen"
+OUTPUT_DIRECTORY       = "@DOXYGEN_OUTPUT_DIR@"
 CREATE_SUBDIRS         = NO
 ALLOW_UNICODE_NAMES    = NO
 OUTPUT_LANGUAGE        = English
-OUTPUT_TEXT_DIRECTION  = None
 BRIEF_MEMBER_DESC      = YES
 REPEAT_BRIEF           = YES
 ABBREVIATE_BRIEF       = "The $name class" \
@@ -29,8 +28,8 @@ ABBREVIATE_BRIEF       = "The $name class" \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = "@PROJECT_BINARY_DIR@/external/eprosima/src/fastrtps/include"
-STRIP_FROM_INC_PATH    = "@PROJECT_BINARY_DIR@/external/eprosima/src/fastrtps/include"
+STRIP_FROM_PATH        = "@DOXYGEN_INPUT_DIR@/.."
+STRIP_FROM_INC_PATH    = "@DOXYGEN_INPUT_DIR@/.."
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
 QT_AUTOBRIEF           = YES
@@ -44,7 +43,6 @@ OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
-OPTIMIZE_OUTPUT_SLICE  = NO
 EXTENSION_MAPPING      =
 MARKDOWN_SUPPORT       = YES
 TOC_INCLUDE_HEADINGS   = 0
@@ -114,7 +112,7 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # Configuration options related to the input files
 #---------------------------------------------------------------------------
-INPUT                  = "@INCLUDE_FILE@"
+INPUT                  = "@DOXYGEN_INPUT_DIR@"
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \
                          *.cc \
@@ -208,7 +206,6 @@ HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
 HTML_COLORSTYLE_GAMMA  = 80
 HTML_TIMESTAMP         = NO
-HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO
 HTML_INDEX_NUM_ENTRIES = 100
 GENERATE_DOCSET        = NO
@@ -259,7 +256,6 @@ GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         =
 MAKEINDEX_CMD_NAME     = makeindex
-LATEX_MAKEINDEX_CMD    = \makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4
 EXTRA_PACKAGES         =
@@ -274,7 +270,6 @@ LATEX_HIDE_INDICES     = NO
 LATEX_SOURCE_CODE      = NO
 LATEX_BIB_STYLE        = plain
 LATEX_TIMESTAMP        = NO
-LATEX_EMOJI_DIRECTORY  =
 #---------------------------------------------------------------------------
 # Configuration options related to the RTF output
 #---------------------------------------------------------------------------
@@ -299,7 +294,6 @@ MAN_LINKS              = NO
 GENERATE_XML           = YES
 XML_OUTPUT             = xml
 XML_PROGRAMLISTING     = YES
-XML_NS_MEMB_FILE_SCOPE = NO
 #---------------------------------------------------------------------------
 # Configuration options related to the DOCBOOK output
 #---------------------------------------------------------------------------

--- a/docs/fastdds/api_reference/dds_pim/core/domainentity.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/domainentity.rst
@@ -7,5 +7,5 @@ DomainEntity
 ------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DomainEntity
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/entity.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/entity.rst
@@ -6,5 +6,5 @@ Entity
 ------
 
 .. doxygenclass:: eprosima::fastdds::dds::Entity
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/policy/datarepresentationid.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/datarepresentationid.rst
@@ -6,5 +6,5 @@ DataRepresentationId
 --------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::DataRepresentationId
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/datarepresentationqospolicy.rst
@@ -6,6 +6,6 @@ DataRepresentationQosPolicy
 ---------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataRepresentationQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/deadlineqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/deadlineqospolicy.rst
@@ -6,6 +6,6 @@ DeadlineQosPolicy
 -----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DeadlineQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/destinationorderqospolicy.rst
@@ -6,6 +6,6 @@ DestinationOrderQosPolicy
 -------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DestinationOrderQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/destinationorderqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/destinationorderqospolicykind.rst
@@ -6,5 +6,5 @@ DestinationOrderQosPolicyKind
 -----------------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::DestinationOrderQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/disablepositiveacksqospolicy.rst
@@ -6,6 +6,6 @@ DisablePositiveACKsQosPolicy
 ----------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DisablePositiveACKsQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/durabilityqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/durabilityqospolicy.rst
@@ -6,6 +6,6 @@ DurabilityQosPolicy
 -------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DurabilityQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/durabilityqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/durabilityqospolicykind.rst
@@ -6,5 +6,5 @@ DurabilityQosPolicyKind
 -----------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::DurabilityQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/durabilityserviceqospolicy.rst
@@ -6,5 +6,5 @@ DurabilityServiceQosPolicy
 --------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DurabilityServiceQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/entityfactoryqospolicy.rst
@@ -6,6 +6,6 @@ EntityFactoryQosPolicy
 ----------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::EntityFactoryQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/genericdataqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/genericdataqospolicy.rst
@@ -6,6 +6,6 @@ GenericDataQosPolicy
 --------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::GenericDataQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/groupdataqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/groupdataqospolicy.rst
@@ -6,5 +6,5 @@ GroupDataQosPolicy
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::GroupDataQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/policy/historyqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/historyqospolicy.rst
@@ -6,6 +6,6 @@ HistoryQosPolicy
 ----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::HistoryQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/historyqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/historyqospolicykind.rst
@@ -6,5 +6,5 @@ HistoryQosPolicyKind
 --------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::HistoryQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/latencybudgetqospolicy.rst
@@ -6,6 +6,6 @@ LatencyBudgetQosPolicy
 ----------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::LatencyBudgetQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/lifespanqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/lifespanqospolicy.rst
@@ -6,6 +6,6 @@ LifespanQosPolicy
 -----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::LifespanQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/livelinessqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/livelinessqospolicy.rst
@@ -6,6 +6,6 @@ LivelinessQosPolicy
 -------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::LivelinessQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/livelinessqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/livelinessqospolicykind.rst
@@ -6,5 +6,5 @@ LivelinessQosPolicyKind
 -----------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::LivelinessQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/ownershipqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/ownershipqospolicy.rst
@@ -6,6 +6,6 @@ OwnershipQosPolicy
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::OwnershipQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/ownershipqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/ownershipqospolicykind.rst
@@ -6,5 +6,5 @@ OwnershipQosPolicyKind
 ----------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::OwnershipQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/ownershipstrengthqospolicy.rst
@@ -6,6 +6,6 @@ OwnershipStrengthQosPolicy
 --------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::OwnershipStrengthQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/partition_t.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/partition_t.rst
@@ -6,6 +6,6 @@ Partition_t
 -----------
 
 .. doxygenclass:: eprosima::fastdds::dds::Partition_t
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/partitionqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/partitionqospolicy.rst
@@ -6,6 +6,6 @@ PartitionQosPolicy
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::PartitionQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/presentationqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/presentationqospolicy.rst
@@ -6,6 +6,6 @@ PresentationQosPolicy
 ---------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::PresentationQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/presentationqospolicyaccessscopekind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/presentationqospolicyaccessscopekind.rst
@@ -6,5 +6,5 @@ PresentationQosPolicyAccessScopeKind
 ------------------------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::PresentationQosPolicyAccessScopeKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/propertypolicyqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/propertypolicyqos.rst
@@ -6,5 +6,5 @@ PropertyPolicyQos
 -----------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::PropertyPolicyQos
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/publishmodeqospolicy.rst
@@ -6,6 +6,6 @@ PublishModeQosPolicy
 --------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::PublishModeQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/publishmodeqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/publishmodeqospolicykind.rst
@@ -6,5 +6,5 @@ PublishModeQosPolicyKind
 ------------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::PublishModeQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/qospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/qospolicy.rst
@@ -6,5 +6,5 @@ QosPolicy
 ---------
 
 .. doxygenclass:: eprosima::fastdds::dds::QosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/readerdatalifecycleqospolicy.rst
@@ -6,6 +6,6 @@ ReaderDataLifecycleQosPolicy
 ----------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::ReaderDataLifecycleQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/reliabilityqospolicy.rst
@@ -6,6 +6,6 @@ ReliabilityQosPolicy
 --------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::ReliabilityQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/reliabilityqospolicykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/reliabilityqospolicykind.rst
@@ -6,5 +6,5 @@ ReliabilityQosPolicyKind
 ------------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::ReliabilityQosPolicyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/resourcelimitsqospolicy.rst
@@ -6,6 +6,6 @@ ResourceLimitsQosPolicy
 -----------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::ResourceLimitsQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/rtpsendpointqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/rtpsendpointqos.rst
@@ -6,6 +6,6 @@ RTPSEndpointQos
 ---------------
 
 .. doxygenclass:: eprosima::fastdds::dds::RTPSEndpointQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/timebasedfilterqospolicy.rst
@@ -6,6 +6,6 @@ TimeBasedFilterQosPolicy
 ------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TimeBasedFilterQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/topicdataqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/topicdataqospolicy.rst
@@ -6,5 +6,5 @@ TopicDataQosPolicy
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TopicDataQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/policy/transportconfigqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/transportconfigqos.rst
@@ -6,6 +6,6 @@ TransportConfigQos
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TransportConfigQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/transportpriorityqospolicy.rst
@@ -6,6 +6,6 @@ TransportPriorityQosPolicy
 --------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TransportPriorityQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/typeconsistencyenforcementqospolicy.rst
@@ -6,6 +6,6 @@ TypeConsistencyEnforcementQosPolicy
 -----------------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TypeConsistencyEnforcementQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/typeconsistencykind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/typeconsistencykind.rst
@@ -6,5 +6,5 @@ TypeConsistencyKind
 -------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::TypeConsistencyKind
-    :project: Fast RTPS
+    :project: FastDDS
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/userdataqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/userdataqospolicy.rst
@@ -6,5 +6,5 @@ UserDataQosPolicy
 -----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::UserDataQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/wireprotocolconfigqos.rst
@@ -6,6 +6,6 @@ WireProtocolConfigQos
 ---------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::WireProtocolConfigQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/writerdatalifecycleqospolicy.rst
@@ -6,6 +6,6 @@ WriterDataLifecycleQosPolicy
 ----------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::WriterDataLifecycleQosPolicy
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/policy/writerresourcelimitsqos.rst
@@ -6,6 +6,6 @@ WriterResourceLimitsQos
 -----------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::WriterResourceLimitsQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/core/status/basestatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/basestatus.rst
@@ -6,5 +6,5 @@ BaseStatus
 ----------
 
 .. doxygenstruct:: eprosima::fastdds::dds::BaseStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/deadlinemissedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/deadlinemissedstatus.rst
@@ -6,5 +6,5 @@ DeadlineMissedStatus
 --------------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::DeadlineMissedStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/incompatibleqosstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/incompatibleqosstatus.rst
@@ -6,5 +6,5 @@ IncompatibleQosStatus
 ---------------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::IncompatibleQosStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/inconsistenttopicstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/inconsistenttopicstatus.rst
@@ -6,4 +6,4 @@ InconsistentTopicStatus
 -----------------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::InconsistentTopicStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/livelinesschangedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/livelinesschangedstatus.rst
@@ -6,5 +6,5 @@ LivelinessChangedStatus
 -----------------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::LivelinessChangedStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/matchedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/matchedstatus.rst
@@ -6,5 +6,5 @@ MatchedStatus
 -------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::MatchedStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/offereddeadlinemissedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/offereddeadlinemissedstatus.rst
@@ -6,4 +6,4 @@ OfferedDeadlineMissedStatus
 ---------------------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::OfferedDeadlineMissedStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/offeredicompatibleqosstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/offeredicompatibleqosstatus.rst
@@ -6,4 +6,4 @@ OfferedIncompatibleQosStatus
 ----------------------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::OfferedIncompatibleQosStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/publicationmatchedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/publicationmatchedstatus.rst
@@ -6,5 +6,5 @@ PublicationMatchedStatus
 ------------------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::PublicationMatchedStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/qospolicycount.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/qospolicycount.rst
@@ -6,5 +6,5 @@ QosPolicyCount
 --------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::QosPolicyCount
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/qospolicycountseq.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/qospolicycountseq.rst
@@ -6,4 +6,4 @@ QosPolicyCountSeq
 -----------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::QosPolicyCountSeq
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/qospolicyid_t.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/qospolicyid_t.rst
@@ -6,4 +6,4 @@ QosPolicyId_t
 -------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::QosPolicyId_t
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/requesteddeadlinemissedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/requesteddeadlinemissedstatus.rst
@@ -6,4 +6,4 @@ RequestedDeadlineMissedStatus
 -----------------------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::RequestedDeadlineMissedStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/requestedicompatibleqosstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/requestedicompatibleqosstatus.rst
@@ -6,4 +6,4 @@ RequestedIncompatibleQosStatus
 ------------------------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::RequestedIncompatibleQosStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/rtpslivelinessloststatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/rtpslivelinessloststatus.rst
@@ -6,4 +6,4 @@ LivelinessLostStatus
 --------------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::LivelinessLostStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/sampleloststatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/sampleloststatus.rst
@@ -6,4 +6,4 @@ SampleLostStatus
 ----------------
 
 .. doxygentypedef:: eprosima::fastdds::dds::SampleLostStatus
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/samplerejectedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/samplerejectedstatus.rst
@@ -6,5 +6,5 @@ SampleRejectedStatus
 --------------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::SampleRejectedStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/core/status/samplerejectedstatuskind.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/samplerejectedstatuskind.rst
@@ -6,4 +6,4 @@ SampleRejectedStatusKind
 ------------------------
 
 .. doxygenenum:: eprosima::fastdds::dds::SampleRejectedStatusKind
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/statusmask.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/statusmask.rst
@@ -6,8 +6,8 @@ StatusMask
 ----------
 
 .. doxygenclass:: eprosima::fastdds::dds::StatusMask
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygendefine:: FASTDDS_STATUS_COUNT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst
+++ b/docs/fastdds/api_reference/dds_pim/core/status/subscriptionmatchedstatus.rst
@@ -6,5 +6,5 @@ SubscriptionMatchedStatus
 -------------------------
 
 .. doxygenstruct:: eprosima::fastdds::dds::SubscriptionMatchedStatus
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/domain/domainparticipant.rst
+++ b/docs/fastdds/api_reference/dds_pim/domain/domainparticipant.rst
@@ -6,5 +6,5 @@ DomainParticipant
 -----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DomainParticipant
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/domain/domainparticipantfactory.rst
+++ b/docs/fastdds/api_reference/dds_pim/domain/domainparticipantfactory.rst
@@ -6,5 +6,5 @@ DomainParticipantFactory
 ------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DomainParticipantFactory
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/domain/domainparticipantfactoryqos.rst
@@ -6,5 +6,5 @@ DomainParticipantFactoryQos
 ---------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DomainParticipantFactoryQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/domain/domainparticipantlistener.rst
+++ b/docs/fastdds/api_reference/dds_pim/domain/domainparticipantlistener.rst
@@ -6,5 +6,5 @@ DomainParticipantListener
 -------------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DomainParticipantListener
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/domain/domainparticipantqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/domain/domainparticipantqos.rst
@@ -6,8 +6,8 @@ DomainParticipantQos
 --------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DomainParticipantQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygenvariable:: eprosima::fastdds::dds::PARTICIPANT_QOS_DEFAULT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/publisher/datawriter.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/datawriter.rst
@@ -6,5 +6,5 @@ DataWriter
 ----------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataWriter
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/publisher/datawriterlistener.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/datawriterlistener.rst
@@ -6,5 +6,5 @@ DataWriterListener
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataWriterListener
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/publisher/datawriterqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/datawriterqos.rst
@@ -6,8 +6,8 @@ DataWriterQos
 -------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataWriterQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygenvariable:: eprosima::fastdds::dds::DATAWRITER_QOS_DEFAULT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/publisher/publisher_class.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/publisher_class.rst
@@ -6,5 +6,5 @@ Publisher
 ---------
 
 .. doxygenclass:: eprosima::fastdds::dds::Publisher
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/publisher/publisherlistener.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/publisherlistener.rst
@@ -6,5 +6,5 @@ PublisherListener
 -----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::PublisherListener
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/publisher/publisherqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/publisherqos.rst
@@ -6,8 +6,8 @@ PublisherQos
 ------------
 
 .. doxygenclass:: eprosima::fastdds::dds::PublisherQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygenvariable:: eprosima::fastdds::dds::PUBLISHER_QOS_DEFAULT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/publisher/rtpsreliablewriterqos.rst
@@ -6,5 +6,5 @@ RTPSReliableWriterQos
 ---------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::RTPSReliableWriterQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/datareader.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/datareader.rst
@@ -6,5 +6,5 @@ DataReader
 ----------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataReader
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/datareaderlistener.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/datareaderlistener.rst
@@ -6,5 +6,5 @@ DataReaderListener
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataReaderListener
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/datareaderqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/datareaderqos.rst
@@ -6,8 +6,8 @@ DataReaderQos
 -------------
 
 .. doxygenclass:: eprosima::fastdds::dds::DataReaderQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygenvariable:: eprosima::fastdds::dds::DATAREADER_QOS_DEFAULT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/subscriber/instancestatekind.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/instancestatekind.rst
@@ -6,4 +6,4 @@ InstanceStateKind
 -----------------
 
 .. doxygenenum:: eprosima::fastdds::dds::InstanceStateKind
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/readerresourcelimitsqos.rst
@@ -6,5 +6,5 @@ ReaderResourceLimitsQos
 -----------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::ReaderResourceLimitsQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/rtpsreliablereaderqos.rst
@@ -6,5 +6,5 @@ RTPSReliableReaderQos
 ---------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::RTPSReliableReaderQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/sampleinfo.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/sampleinfo.rst
@@ -6,5 +6,5 @@ SampleInfo
 ----------
 
 .. doxygenstruct:: eprosima::fastdds::dds::SampleInfo
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/samplestatekind.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/samplestatekind.rst
@@ -6,4 +6,4 @@ SampleStateKind
 ---------------
 
 .. doxygenenum:: eprosima::fastdds::dds::SampleStateKind
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/subscriber/subscriber_class.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/subscriber_class.rst
@@ -6,5 +6,5 @@ Subscriber
 ----------
 
 .. doxygenclass:: eprosima::fastdds::dds::Subscriber
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/subscriberlistener.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/subscriberlistener.rst
@@ -6,5 +6,5 @@ SubscriberListener
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::SubscriberListener
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/subscriberqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/subscriberqos.rst
@@ -6,8 +6,8 @@ SubscriberQos
 -------------
 
 .. doxygenclass:: eprosima::fastdds::dds::SubscriberQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygenvariable:: eprosima::fastdds::dds::SUBSCRIBER_QOS_DEFAULT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/subscriber/typeconsistencyqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/typeconsistencyqos.rst
@@ -6,5 +6,5 @@ TypeConsistencyQos
 ------------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TypeConsistencyQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/subscriber/viewstatekind.rst
+++ b/docs/fastdds/api_reference/dds_pim/subscriber/viewstatekind.rst
@@ -6,4 +6,4 @@ ViewStateKind
 -------------
 
 .. doxygenenum:: eprosima::fastdds::dds::ViewStateKind
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/topic/topic_class.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/topic_class.rst
@@ -6,5 +6,5 @@ Topic
 -----
 
 .. doxygenclass:: eprosima::fastdds::dds::Topic
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/topic/topicdatatype.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/topicdatatype.rst
@@ -6,5 +6,5 @@ TopicDataType
 -------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TopicDataType
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/topic/topicdescription.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/topicdescription.rst
@@ -6,5 +6,5 @@ TopicDescription
 ----------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TopicDescription
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/topic/topiclistener.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/topiclistener.rst
@@ -6,5 +6,5 @@ TopicListener
 -------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TopicListener
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/topic/topicqos.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/topicqos.rst
@@ -6,8 +6,8 @@ TopicQos
 --------
 
 .. doxygenclass:: eprosima::fastdds::dds::TopicQos
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 
 .. doxygenvariable:: eprosima::fastdds::dds::TOPIC_QOS_DEFAULT
-    :project: Fast RTPS
+    :project: FastDDS

--- a/docs/fastdds/api_reference/dds_pim/topic/typeidv1.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/typeidv1.rst
@@ -6,6 +6,6 @@ TypeIdV1
 --------
 
 .. doxygenclass:: eprosima::fastdds::dds::TypeIdV1
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/topic/typeinformation.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/typeinformation.rst
@@ -6,5 +6,5 @@ TypeInformation
 ---------------
 
 .. doxygenclass:: eprosima::fastdds::dds::xtypes::TypeInformation
-    :project: Fast RTPS
+    :project: FastDDS
     :members:

--- a/docs/fastdds/api_reference/dds_pim/topic/typeobjectv1.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/typeobjectv1.rst
@@ -6,6 +6,6 @@ TypeObjectV1
 ------------
 
 .. doxygenclass:: eprosima::fastdds::dds::TypeObjectV1
-    :project: Fast RTPS
+    :project: FastDDS
     :members:
 

--- a/docs/fastdds/api_reference/dds_pim/topic/typesupport.rst
+++ b/docs/fastdds/api_reference/dds_pim/topic/typesupport.rst
@@ -6,5 +6,5 @@ TypeSupport
 -----------
 
 .. doxygenclass:: eprosima::fastdds::dds::TypeSupport
-    :project: Fast RTPS
+    :project: FastDDS
     :members:


### PR DESCRIPTION
Read the docs merely runs Sphinx, and therefore our Doxygen documentacion generated with CMake is not present. The way to solve this is to use conf.py to configure the Doxyfile and run Doxygen if the `READTHEDOCS` environment variable is set to `TRUE`.

This PR:
* Moves the Sphinx documentation generation to CMake. This saves the duplicity that occurred before when running `make test`
* Enables Doxygen documentation generation in readthedocs via conf.py
* Removes deprecate Doxyfile attributes
* Change Breathe project to FastDDS

Kudos to [this tutorial](https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/)