### PR TITLE
Download Fast DDS if running on Read the Docs [8473]

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This means that it does not execute `make` and therefore Fast DDS is not downloa
 This is done by the mean of the environment variable `READTHEDOCS`.
 When this variable is set to `True`, [conf.py](docs/conf.py) will clone Fast DDS in `build/code/external/eprosima/src/` (same place as CMake) and will set it to a branch applying the following criteria:
 
-1. Try to checkout to the branch specified by `${FASTRTPS_BRANCH}`.
+1. Try to checkout to the branch specified by `FASTRTPS_BRANCH`.
 1. If the variable is not set, or the branch does not exist, try to checkout to a branch with the same name as the current branch on this repository.
 1. If the previous fails, fallback to `master`.
 
@@ -130,10 +130,10 @@ cd ~/fastrtps-docs
 rm -rf build
 ```
 
-Then, set `${FASTRTPS_BRANCH}` and run sphinx:
+Then, set `READTHEDOCS`, `FASTRTPS_BRANCH` and run sphinx:
 
 ```bash
-FASTRTPS_BRANCH=<branch> sphinx-build \
+READTHEDOCS=True FASTRTPS_BRANCH=<branch> sphinx-build \
     -b html \
     -Dbreathe_projects.FastDDS=<abs_path_to_docs_repo>/fastrtps-docs/build/code/doxygen/xml \
     -d <abs_path_to_docs_repo>/fastrtps-docs/build/doctrees \

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ eprosima Fast RTPS is a C++ implementation of the RTPS (Real Time Publish Subscr
 For more information about the library, check out the [Fast-RTPS documentation](https://fast-rtps.docs.eprosima.com/en/latest/).
 You can find all the library's source code on our [GitHub repository](https://github.com/eProsima/Fast-RTPS).
 
+1. [Installation Guide](#installation-guide)
+1. [Getting Started](#getting-started)
+1. [Generating documentation in other formats](#generating-documentation-in-other-formats)
+1. [Running documentation tests](#running-documentation-tests)
+1. [Simulating Read the Docs](#simulating-read-the-docs)
+
 ## Installation Guide
 
 1. In order to build and test the documentation, some dependencies must be installed beforehand:
@@ -104,4 +110,32 @@ Run the tests by:
 cd ~/fastrtps-docs
 source fastrtps-docs-venv/bin/activate
 FASTRTPS_BRANCH=<branch> make test
+```
+
+## Simulating Read the Docs
+
+Read the Docs does generates the documentation using Sphinx and [conf.py](docs/conf.py).
+This means that it does not execute `make` and therefore Fast DDS is not downloaded for API reference documentation generation. [conf.py](docs/conf.py) provides some extra logic to download Fast DDS and generate the Doxygen documentation when running on a Read the Docs environment.
+This is done by the mean of the environment variable `READTHEDOCS`.
+When this variable is set to `True`, [conf.py](docs/conf.py) will clone Fast DDS in `build/code/external/eprosima/src/` (same place as CMake) and will set it to a branch applying the following criteria:
+
+1. Try to checkout to the branch specified by `${FASTRTPS_BRANCH}`.
+1. If the variable is not set, or the branch does not exist, try to checkout to a branch with the same name as the current branch on this repository.
+1. If the previous fails, fallback to `master`.
+
+To simulating Read the Docs operation, make sure you do not have a `build` directory.
+
+```bash
+cd ~/fastrtps-docs
+rm -rf build
+```
+
+Then, set `${FASTRTPS_BRANCH}` and run sphinx:
+
+```bash
+FASTRTPS_BRANCH=<branch> sphinx-build \
+    -b html \
+    -Dbreathe_projects.FastDDS=<abs_path_to_docs_repo>/fastrtps-docs/build/code/doxygen/xml \
+    -d <abs_path_to_docs_repo>/fastrtps-docs/build/doctrees \
+    docs <abs_path_to_docs_repo>/fastrtps-docs/build/html
 ```

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ FASTRTPS_BRANCH=<branch> make test
 
 ## Simulating Read the Docs
 
-Read the Docs does generates the documentation using Sphinx and [conf.py](docs/conf.py).
-This means that it does not execute `make` and therefore Fast DDS is not downloaded for API reference documentation generation. [conf.py](docs/conf.py) provides some extra logic to download Fast DDS and generate the Doxygen documentation when running on a Read the Docs environment.
-This is done by the mean of the environment variable `READTHEDOCS`.
+Read the Docs generates the documentation using Sphinx and [conf.py](docs/conf.py).
+This means that it does not execute `make` and therefore Fast DDS is not downloaded for API reference documentation generation.
+[conf.py](docs/conf.py) provides some extra logic to download Fast DDS and generate the Doxygen documentation when running on a Read the Docs environment.
+This is done by means of the environment variable `READTHEDOCS`.
 When this variable is set to `True`, [conf.py](docs/conf.py) will clone Fast DDS in `build/code/external/eprosima/src/` (same place as CMake) and will set it to a branch applying the following criteria:
 
 1. Try to checkout to the branch specified by `FASTRTPS_BRANCH`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 import pathlib
+import shutil
 import subprocess
 
 import git
@@ -37,11 +38,7 @@ def get_git_branch():
             cwd=path_to_here
         )
 
-        # Will contain something like "* (HEAD detached at origin/MYBRANCH)"
-        # or something like "* MYBRANCH"
-        branch_output = p.communicate()[0].decode().rstrip()
-        print(branch_output)
-        return branch_output
+        return p.communicate()[0].decode().rstrip()
 
     except Exception:
         print('Could not get the branch')
@@ -107,14 +104,24 @@ input_dir = os.path.abspath(
 # Check if we're running on Read the Docs' servers
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
-    # Download Fast DDS
-    print('Cloning Fast DDS')
+    print('Read the Docs environment detected!')
+
     fastdds_repo_name = os.path.abspath(
         '{}/external/eprosima/src/fastrtps'.format(
             project_binary_dir
         )
     )
+
+    # Remove repository if exists
+    if os.path.isdir(fastdds_repo_name):
+        print('Removing existing repository in {}'.format(fastdds_repo_name))
+        shutil.rmtree(fastdds_repo_name)
+
+    # Create necessary directory path
     os.makedirs(os.path.dirname(fastdds_repo_name), exist_ok=True)
+
+    # Clone repository
+    print('Cloning Fast DDS')
     fastdds = git.Repo.clone_from(
         'https://github.com/eProsima/Fast-RTPS.git',
         fastdds_repo_name,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ def configure_doxyfile(
     filedata = filedata.replace('@PROJECT_BINARY_DIR@', project_binary_dir)
     filedata = filedata.replace('@PROJECT_SOURCE_DIR@', project_source_dir)
 
+    os.makedirs(os.path.dirname(doxyfile_out), exist_ok=True)
     with open(doxyfile_out, 'w') as file:
         file.write(filedata)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,34 @@ import os
 import pathlib
 import subprocess
 
+import git
+
+
+def get_git_branch():
+    """Get the git branch this repository is currently on."""
+    path_to_here = os.path.abspath(os.path.dirname(__file__))
+
+    # Invoke git to get the current branch which we use to get the theme
+    try:
+        p = subprocess.Popen(
+            ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+            stdout=subprocess.PIPE,
+            cwd=path_to_here
+        )
+
+        # Will contain something like "* (HEAD detached at origin/MYBRANCH)"
+        # or something like "* MYBRANCH"
+        branch_output = p.communicate()[0].decode().rstrip()
+        print(branch_output)
+        return branch_output
+
+    except Exception:
+        print('Could not get the branch')
+
+    # Couldn't figure out the branch probably due to an error
+    return None
+
+
 def configure_doxyfile(
     doxyfile_in,
     doxyfile_out,
@@ -53,24 +81,74 @@ def configure_doxyfile(
     with open(doxyfile_out, 'w') as file:
         file.write(filedata)
 
-script_path = pathlib.Path(__file__).parent.absolute()
+
+script_path = os.path.abspath(pathlib.Path(__file__).parent.absolute())
 # Project directories
-project_source_dir = '{}/../code'.format(script_path)
-project_binary_dir = '{}/../build/code'.format(script_path)
-output_dir = '{}/doxygen'.format(project_binary_dir)
+project_source_dir = os.path.abspath('{}/../code'.format(script_path))
+project_binary_dir = os.path.abspath('{}/../build/code'.format(script_path))
+output_dir = os.path.abspath('{}/doxygen'.format(project_binary_dir))
+doxygen_html = os.path.abspath('{}/html/doxygen'.format(project_binary_dir))
+os.makedirs(os.path.dirname(output_dir), exist_ok=True)
+os.makedirs(os.path.dirname(doxygen_html), exist_ok=True)
 
 # Doxyfile
-doxyfile_in = '{}/doxygen-config.in'.format(project_source_dir)
-doxyfile_out = '{}/doxygen-config'.format(project_binary_dir)
+doxyfile_in = os.path.abspath(
+    '{}/doxygen-config.in'.format(project_source_dir)
+)
+doxyfile_out = os.path.abspath('{}/doxygen-config'.format(project_binary_dir))
 
 # Header files
-input_dir = '{}/external/eprosima/src/fastrtps/include/fastdds'.format(
-    project_binary_dir
+input_dir = os.path.abspath(
+    '{}/external/eprosima/src/fastrtps/include/fastdds'.format(
+        project_binary_dir
+    )
 )
 
 # Check if we're running on Read the Docs' servers
 read_the_docs_build = os.environ.get('READTHEDOCS', None) == 'True'
 if read_the_docs_build:
+    # Download Fast DDS
+    print('Cloning Fast DDS')
+    fastdds_repo_name = os.path.abspath(
+        '{}/external/eprosima/src/fastrtps'.format(
+            project_binary_dir
+        )
+    )
+    os.makedirs(os.path.dirname(fastdds_repo_name), exist_ok=True)
+    fastdds = git.Repo.clone_from(
+        'https://github.com/eProsima/Fast-RTPS.git',
+        fastdds_repo_name,
+    )
+
+    # Documentation repository branch
+    docs_branch = get_git_branch()
+    print('Current documentation branch is "{}"'.format(docs_branch))
+
+    # User specified Fast DDS branch
+    fastdds_branch = os.environ.get('FASTRTPS_BRANCH', None)
+
+    # First try to checkout to ${FASTRTPS_BRANCH}
+    # Else try with current documentation branch
+    # Else checkout to master
+    if (fastdds_branch and
+            fastdds.refs.__contains__('origin/{}'.format(fastdds_branch))):
+        fastdds_branch = 'origin/{}'.format(fastdds_branch)
+    elif (docs_branch and
+            fastdds.refs.__contains__('origin/{}'.format(docs_branch))):
+        fastdds_branch = 'origin/{}'.format(docs_branch)
+    else:
+        print(
+            'Fast DDS does not have either "{}" or "{}" branches'.format(
+                fastdds_branch,
+                docs_branch
+            )
+        )
+        fastdds_branch = 'origin/master'
+
+    # Actual checkout
+    print('Checking out Fast DDS branch "{}"'.format(fastdds_branch))
+    fastdds.refs[fastdds_branch].checkout()
+
     # Configure Doxyfile
     configure_doxyfile(
         doxyfile_in,
@@ -84,7 +162,7 @@ if read_the_docs_build:
     subprocess.call('doxygen {}'.format(doxyfile_out), shell=True)
 
 breathe_projects = {
-    'FastDDS': '{}/xml'.format(output_dir)
+    'FastDDS': os.path.abspath('{}/xml'.format(output_dir))
 }
 breathe_default_project = 'FastDDS'
 


### PR DESCRIPTION
This PR completes the functionality that #138 was intended to add. 

Read the Docs documentation is generated directly with shpinx, meaning no use of `make` and therefore `CMake`. This meant that Fast DDS was not being downloaded, so the Doxygen documentation could not be generated. 

This PR fixes this issue by detecting when running on Read the Docs and acting accordingly. It also provides a small description on how to simulate the Read the Docs build environment locally.