### PR TITLE
Update CMake options in Logging section.

### DIFF
--- a/docs/fastdds/logging/disable_module.rst
+++ b/docs/fastdds/logging/disable_module.rst
@@ -35,5 +35,4 @@ for debugging purposes, thus preventing them to impact performance.
 
 .. warning::
 
-    ``INTERNAL_DEBUG`` can be automatically set to ``ON`` if CMake option ``EPROSIMA_BUILD`` is set to ``ON`` and CMake
-    option ``EPROSIMA_INSTALLER_MINION`` is set to ``OFF`` at the same time.
+    ``INTERNAL_DEBUG`` can be automatically set to ``ON`` if CMake option ``EPROSIMA_BUILD`` is set to ``ON``.


### PR DESCRIPTION
This PR removes EPROSIMA_INSTALLER_MINION documentation from the Logging section.