### PR TITLE
Remove SHM as default on overview

### DIFF
--- a/docs/fastdds/library_overview/includes/architecture.rst
+++ b/docs/fastdds/library_overview/includes/architecture.rst
@@ -103,10 +103,6 @@ Transport layer
 
 Fast DDS supports the implementation of applications over various transport protocols.
 Those are UDPv4, UDPv6, TCPv4, TCPv6 and Shared Memory Transport (SHM).
-By default, a DomainParticipant implements two transport protocols:
-
-* **SHM**: for communications between DomainParticipants in the same machine.
-* **UDPv4**: for inter machine communications.
-
+By default, a DomainParticipant implements a UDPv4 transport protocol.
 The configuration of all supported transport protocols is detailed in the :ref:`comm-transports-configuration` section.
 


### PR DESCRIPTION
This comment was skipped when removing the references to SHM not being active by default