### PR TITLE
how to combine verify modes and options in TLS

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -3213,7 +3213,8 @@ void dds_transport_examples ()
         using TLSVerifyMode = eprosima::fastdds::rtps::TCPTransportDescriptor::TLSConfig::TLSVerifyMode;
         tls_transport->apply_security = true;
         tls_transport->tls_config.verify_file = "ca.pem";
-        tls_transport->tls_config.verify_mode = TLSVerifyMode::VERIFY_PEER;
+        tls_transport->tls_config.add_verify_mode(TLSVerifyMode::VERIFY_PEER);
+        tls_transport->tls_config.add_verify_mode(TLSVerifyMode::VERIFY_FAIL_IF_NO_PEER_CERT);
         tls_transport->tls_config.add_option(TLSOptions::DEFAULT_WORKAROUNDS);
         tls_transport->tls_config.add_option(TLSOptions::SINGLE_DH_USE);
         tls_transport->tls_config.add_option(TLSOptions::NO_SSLV2);

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -573,6 +573,7 @@
                 <verify_file>ca.pem</verify_file>
                 <verify_mode>
                     <verify>VERIFY_PEER</verify>
+                    <verify>VERIFY_FAIL_IF_NO_PEER_CERT</verify>
                 </verify_mode>
                 <options>
                     <option>DEFAULT_WORKAROUNDS</option>

--- a/docs/fastdds/transport/tcp/tls.rst
+++ b/docs/fastdds/transport/tcp/tls.rst
@@ -103,7 +103,8 @@ TLS Verification Mode
 
 The verification mode defines how the peer node will be verified.
 The following table describes the available verification options.
-Several verification options can be combined in the same :ref:`transport_tcp_transportDescriptor`.
+Several verification options can be combined in the same :ref:`transport_tcp_transportDescriptor`
+using the :func:`add_verify_mode` member function.
 
 +---------------------------------+-----------------------------------------------------------------------------------+
 | Value                           | Description                                                                       |
@@ -127,7 +128,8 @@ TLS Options
 
 These options define which TLS features are to be supported.
 The following table describes the available options.
-Several options can be combined in the same :ref:`transport_tcp_transportDescriptor`.
+Several options can be combined in the same :ref:`transport_tcp_transportDescriptor`
+using the :func:`add_option` member function.
 
 +---------------------------------+-----------------------------------------------------------------------------------+
 | Value                           | Description                                                                       |


### PR DESCRIPTION
Add a comment explaining how the option and verify mode values can take compound values combining several enums. 
Also C++ and XML examples have been adapted to reflect this.