### PR TITLE
 RTPS payload pool [9544]

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -933,16 +933,112 @@ void rtps_api_example_create_entities()
     }
 
     //RTPS_API_WRITE_SAMPLE
-    //Request a change from the history
+    //Request a change from the writer
     CacheChange_t* change = writer->new_change([]() -> uint32_t {
         return 255;
     }, ALIVE);
     //Write serialized data into the change
     change->serializedPayload.length = sprintf((char*) change->serializedPayload.data, "My example string %d", 2) + 1;
-    //Insert change back into the history. The Writer takes care of the rest.
+    //Insert change into the history. The Writer takes care of the rest.
     history->add_change(change);
     //!--
+}
 
+
+void rtps_api_example_create_entities_with_custom_pool()
+{
+    RTPSParticipantAttributes participant_attr;
+    participant_attr.setName("participant");
+    RTPSParticipant* participant = RTPSDomain::createParticipant(0, participant_attr);
+
+    //RTPS_API_ENTITY_CREATE_WITH_PAYLOAD_POOL
+    // A simple payload pool that reserves and frees memory each time
+    class CustomPayloadPool : public IPayloadPool
+    {
+        bool get_payload(
+            uint32_t size,
+            CacheChange_t& cache_change) override
+        {
+            // Reserve new memory for the payload buffer
+            octet* payload = new octet[size];
+
+            // Assign the payload buffer to the CacheChange and update sizes
+            cache_change.serializedPayload.data = payload;
+            cache_change.serializedPayload.length = size;
+            cache_change.serializedPayload.max_size = size;
+
+            // Tell the CacheChange who needs to release ist payload
+            cache_change.payload_owner(this);
+            
+            return true;
+        }
+
+        bool get_payload(
+                SerializedPayload_t& data,
+                IPayloadPool*& /* data_owner */,
+                CacheChange_t& cache_change) override
+        {
+            // Reserve new memory for the payload buffer
+            octet* payload = new octet[data.length];
+
+            // Copy the data
+            memcpy(payload, data.data, data.length);
+
+            // Assign the payload buffer to the CacheChange and update sizes
+            cache_change.serializedPayload.data = payload;
+            cache_change.serializedPayload.length = data.length;
+            cache_change.serializedPayload.max_size = data.length;
+
+            // Tell the CacheChange who needs to release ist payload
+            cache_change.payload_owner(this);
+            
+            return true;
+        }
+
+        bool release_payload(
+                CacheChange_t& cache_change) override
+        {
+            // Dealloc the buffer of the payload
+            delete[] cache_change.serializedPayload.data;
+
+            // Reset sizes and pointers
+            cache_change.serializedPayload.data = nullptr;
+            cache_change.serializedPayload.length = 0;
+            cache_change.serializedPayload.max_size = 0;
+
+            // Reset the owner of the payload
+            cache_change.payload_owner(nullptr);
+
+            return true;
+        }
+    };
+
+    CustomPayloadPool payload_pool;
+
+    // A writer using the custom payload pool
+    HistoryAttributes history_attr;
+    WriterHistory* history = new WriterHistory(history_attr);
+    WriterAttributes writer_attr;
+    RTPSWriter* writer = RTPSDomain::createRTPSWriter(participant, writer_attr, payload_pool, history);
+
+    // A reader using the same instance of the custom payload pool
+    HistoryAttributes history_attr;
+    ReaderHistory* history = new ReaderHistory(history_attr);
+    ReaderAttributes reader_attr;
+    RTPSReader* reader = RTPSDomain::createRTPSReader(participant, reader_attr, payload_pool, history);
+
+    // Write and Read operations work as usual, but take the Payloads from the poo.
+    // Requesting a change to the Writer will provide one with an empty Payload taken from the pool
+    CacheChange_t* change = writer->new_change([]() -> uint32_t {
+        return 255;
+    }, ALIVE);
+
+    // Write serialized data into the change and add it to the history
+    change->serializedPayload.length = sprintf((char*) change->serializedPayload.data, "My example string %d", 2) + 1;
+    history->add_change(change);
+
+
+    //!--
 }
 
 void rtps_api_example_conf()

--- a/docs/03-exports/aliases-api.include
+++ b/docs/03-exports/aliases-api.include
@@ -573,10 +573,39 @@
 .. |DomainId-api| replace:: :cpp:type:`DomainId <dds::fastdds::eprosima::DomainId_t>`
 .. |c_InstanceHandle_Unknown-api| replace:: :cpp:member:`c_InstanceHandle_Unknown <rtps::fastrtps::eprosima::c_InstanceHandle_Unknown>`
 
+.. |RTPSDomain-api| replace:: :cpp:class:`RTPSDomain <eprosima::fastrtps::rtps::RTPSDomain>`
+.. |RTPSDomain::createParticipant-api| replace:: :cpp:func:`RTPSDomain::createParticipant() <eprosima::fastrtps::rtps::RTPSDomain::createParticipant>`
+.. |RTPSDomain::createRTPSWriter-api| replace:: :cpp:func:`RTPSDomain::createRTPSWriter() <eprosima::fastrtps::rtps::RTPSDomain::createRTPSWriter>`
+.. |RTPSDomain::createRTPSReader-api| replace:: :cpp:func:`RTPSDomain::createRTPSReader() <eprosima::fastrtps::rtps::RTPSDomain::createRTPSReader>`
+
 .. |RTPSParticipants-api| replace:: :cpp:class:`RTPSParticipants <eprosima::fastrtps::rtps::RTPSParticipant>`
 .. |RTPSParticipant-api| replace:: :cpp:class:`RTPSParticipant <eprosima::fastrtps::rtps::RTPSParticipant>`
+.. |RTPSParticipantAttributes-api| replace:: :cpp:class:`RTPSParticipantAttributes<eprosima::fastrtps::rtps::RTPSParticipantAttributes>`
+
 .. |RTPSReaders-api| replace:: :cpp:class:`RTPSReaders <eprosima::fastrtps::rtps::RTPSReader>`
+.. |ReaderAttributes-api| replace:: :cpp:class:`ReaderAttributes<eprosima::fastrtps::rtps::ReaderAttributes>`
+.. |ReaderListener-api| replace:: :cpp:class:`ReaderListener<eprosima::fastrtps::rtps::ReaderListener>`
+.. |ReaderListener::onNewCacheChangeAdded-api| replace:: :cpp:func:`ReaderListener::onNewCacheChangeAdded<eprosima::fastrtps::rtps::ReaderListener::onNewCacheChangeAdded>`
+
 .. |RTPSWriters-api| replace:: :cpp:class:`RTPSWriters <eprosima::fastrtps::rtps::RTPSWriter>`
+.. |WriterAttributes-api| replace:: :cpp:class:`WriterAttributes<eprosima::fastrtps::rtps::WriterAttributes>`
+.. |RTPSWriters::new_change-api| replace:: :cpp:func:`RTPSWriter::new_change() <eprosima::fastrtps::rtps::RTPSWriter::new_change>`
+
+.. |History-api| replace:: :cpp:class:`History <eprosima::fastrtps::rtps::History>`
+.. |WriterHistory-api| replace:: :cpp:class:`WriterHistory <eprosima::fastrtps::rtps::WriterHistory>`
+.. |WriterHistory::add_change-api| replace:: :cpp:func:`WriterHistory::add_change() <eprosima::fastrtps::rtps::WriterHistory::add_change>`
+.. |ReaderHistory-api| replace:: :cpp:class:`ReaderHistory <eprosima::fastrtps::rtps::ReaderHistory>`
+.. |CacheChange_t-api| replace:: :cpp:class:`CacheChange_t<eprosima::fastrtps::rtps::CacheChange_t>`
+
+.. |HistoryAttributes-api| replace:: :cpp:class:`HistoryAttributes<eprosima::fastrtps::rtps::HistoryAttributes>`
+.. |HistoryAttributes::memoryPolicy-api| replace:: :cpp:member:`memoryPolicy<eprosima::fastrtps::rtps::HistoryAttributes::memoryPolicy>`
+.. |HistoryAttributes::payloadMaxSize-api| replace:: :cpp:member:`payloadMaxSize<eprosima::fastrtps::rtps::HistoryAttributes::payloadMaxSize>`
+.. |HistoryAttributes::initialReservedCaches-api| replace:: :cpp:member:`initialReservedCaches<eprosima::fastrtps::rtps::HistoryAttributes::initialReservedCaches>`
+
+.. |IPayloadPool-api| replace:: :cpp:class:`IPayloadPool <eprosima::fastrtps::rtps::IPayloadPool>`
+.. |IPayloadPool::get_payload-api| replace:: :cpp:func:`IPayloadPool::get_payload <eprosima::fastrtps::rtps::IPayloadPool::get_payload>`
+.. |IPayloadPool::release_payload-api| replace:: :cpp:func:`IPayloadPool::release_payload <eprosima::fastrtps::rtps::IPayloadPool::release_payload>`
+
 
 .. |DiscoverySettings-api| replace:: :cpp:class:`DiscoverySettings <eprosima::fastrtps::rtps::DiscoverySettings>`
 .. |leaseDuration_announcementperiod| replace:: :cpp:member:`leaseDuration_announcementperiod <eprosima::fastrtps::rtps::DiscoverySettings::leaseDuration_announcementperiod>`
@@ -675,3 +704,4 @@
 .. |Subscriber::set_listener-api| replace:: :cpp:func:`Subscriber::set_listener()<eprosima::fastdds::dds::Subscriber::set_listener>`
 .. |DataReader::set_listener-api| replace:: :cpp:func:`DataReader::set_listener()<eprosima::fastdds::dds::DataReader::set_listener>`
 .. |Topic::set_listener-api| replace:: :cpp:func:`Topic::set_listener()<eprosima::fastdds::dds::Topic::set_listener>`
+

--- a/docs/fastdds/api_reference/rtps/history/IChangePool.rst
+++ b/docs/fastdds/api_reference/rtps/history/IChangePool.rst
@@ -1,0 +1,8 @@
+.. rst-class:: api-ref
+
+IChangePool
+--------------------------------
+
+.. doxygenclass:: eprosima::fastrtps::rtps::IChangePool
+    :project: FastDDS
+    :members:

--- a/docs/fastdds/api_reference/rtps/history/IPayloadPool.rst
+++ b/docs/fastdds/api_reference/rtps/history/IPayloadPool.rst
@@ -1,0 +1,8 @@
+.. rst-class:: api-ref
+
+IPayloadPool
+--------------------------------
+
+.. doxygenclass:: eprosima::fastrtps::rtps::IPayloadPool
+    :project: FastDDS
+    :members:

--- a/docs/fastdds/api_reference/rtps/history/history.rst
+++ b/docs/fastdds/api_reference/rtps/history/history.rst
@@ -8,5 +8,7 @@ History
     /fastdds/api_reference/rtps/history/History
     /fastdds/api_reference/rtps/history/ReaderHistory
     /fastdds/api_reference/rtps/history/WriterHistory
+    /fastdds/api_reference/rtps/history/IChangePool
+    /fastdds/api_reference/rtps/history/IPayloadPool
 
 

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -280,3 +280,11 @@ Released Payloads can be reused for another :class:`CacheChange_t`.
 If there is at least one free Payload with a buffer size equal or larger to the requested one,
 no memory allocation is done.
 
+Example using a custom Payload pool
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../../../code/CodeTester.cpp
+    :language: c++
+    :start-after: //RTPS_API_ENTITY_CREATE_WITH_PAYLOAD_POOL
+    :end-before: //!--
+    :dedent: 4

--- a/docs/fastdds/rtps_layer/rtps_layer.rst
+++ b/docs/fastdds/rtps_layer/rtps_layer.rst
@@ -1,3 +1,5 @@
+.. include:: ../../03-exports/aliases-api.include
+
 .. _rtps_layer:
 
 RTPS Layer
@@ -33,14 +35,15 @@ How to use the RTPS Layer
 We will now go over the use of the RTPS Layer like we did with the :ref:`dds_layer` one,
 explaining the new features it presents.
 
-We recommend you to look at the two examples of how to use this layer the distribution comes with while reading
-this section. They are located in `examples/RTPSTest_as_socket` and in `examples/RTPSTest_registered`
+We recommend you to look at the two examples describing how to use the RTPS layer that come with the distribution
+while reading this section.
+They are located in `examples/RTPSTest_as_socket` and in `examples/RTPSTest_registered`
 
 Managing the Participant
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Creating a :class:`RTPSParticipant` is done with :func:`RTPSDomain::createParticipant`.
-:class:`RTPSParticipantAttributes` structure is used to configure the :class:`RTPSParticipant` upon creation.
+Creating a |RTPSParticipant-api| is done with |RTPSDomain::createParticipant-api|.
+|RTPSParticipantAttributes-api| structure is used to configure the :class:`RTPSParticipant` upon creation.
 
 .. literalinclude:: ../../../code/CodeTester.cpp
     :language: c++
@@ -51,12 +54,12 @@ Creating a :class:`RTPSParticipant` is done with :func:`RTPSDomain::createPartic
 Managing the Writers and Readers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As the RTPS standard specifies, Writers and Readers are always associated with a History element.
+As the RTPS standard specifies, |RTPSWriters-api| and |RTPSReaders-api| are always associated with a |History-api| element.
 In the :ref:`dds_layer`, its creation and management is hidden,
 but in the :ref:`rtps_layer`, you have full control over its creation and configuration.
 
-Writers are created with :func:`RTPSDomain::createRTPSWriter` and configured with a :class:`WriterAttributes` structure.
-They also need a :class:`WriterHistory` which is configured with a :class:`HistoryAttributes` structure.
+Writers are created with |RTPSDomain::createRTPSWriter-api| and configured with a |WriterAttributes-api| structure.
+They also need a |WriterHistory-api| which is configured with a |HistoryAttributes-api| structure.
 
 .. literalinclude:: ../../../code/CodeTester.cpp
     :language: c++
@@ -64,8 +67,10 @@ They also need a :class:`WriterHistory` which is configured with a :class:`Histo
     :end-before: //!--
     :dedent: 4
 
-The creation of a Reader is similar to that of the Writers.
-Note that in this case, you can provide a specialization of :class:`ReaderListener` class that implements your
+Similar to the creation of Writers, Readers are created with |RTPSDomain::createRTPSReader-api|
+and configured with a |ReaderAttributes-api| structure.
+A |HistoryAttributes-api| structure is used to configure the required |ReaderHistory-api|.
+Note that in this case, you can provide a specialization of |ReaderListener-api| class that implements your
 callbacks:
 
 .. literalinclude:: ../../../code/CodeTester.cpp
@@ -78,15 +83,19 @@ Using the History to Send and Receive Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In the RTPS Protocol, Readers and Writers save the data about a topic in their associated History.
-Each piece of data is represented by a Change, which *eprosima Fast DDS* implements as :class:`CacheChange_t`.
-Changes are always managed by the History. As a user, the procedure for interacting with the History is always the same:
+Each piece of data is represented by a Change, which *eprosima Fast DDS* implements as |CacheChange_t-api|.
+Changes are always managed by the History.
 
-1. Request a :class:`CacheChange_t` from the History
-2. Use it
-3. Release it
+You can add a new :class:`CacheChange_t` to the History of the Writer to send data.
+The procedure is as follows:
 
-You can interact with the History of the Writer to send data.
-A callback that returns the maximum number of payload bytes is required:
+1. Request a :class:`CacheChange_t` from the Writer with |RTPSWriters::new_change-api|.
+   In order to allocate enough memory,
+   you need to provide a callback that returns the maximum number bytes in the payload.
+2. Fill the :class:`CacheChange_t` with the data.
+3. Add it to the History with |WriterHistory::add_change-api|.
+
+The Writer will take care of everything to communicate the data to the Readers.
 
 .. literalinclude:: ../../../code/CodeTester.cpp
     :language: c++
@@ -98,7 +107,13 @@ If your topic data type has several fields, you will have to provide functions t
 your data in and out of the :class:`CacheChange_t`.
 *Fast DDS-Gen* does this for you.
 
-You can receive data from within a :class:`ReaderListener` callback method as we did in the :ref:`dds_layer`:
+You can receive data from within the |ReaderListener::onNewCacheChangeAdded-api| callback,
+as we did in the :ref:`dds_layer`:
+
+1. The callback receives a :class:`CacheChange_t` parameter containing the received data.
+2. Process the data within the received :class:`CacheChange_t`.
+3. Inform the Reader's History that the change is not needed anymore.
+
 
 .. literalinclude:: ../../../code/CodeTester.cpp
     :language: c++
@@ -146,7 +161,7 @@ sends all changes you have not explicitly released from the History.
 Configuring the History
 -----------------------
 
-The History has its own configuration structure, the :class:`HistoryAttributes`.
+The History has its own configuration structure, the |HistoryAttributes-api|.
 
 Changing the maximum size of the payload
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -46,7 +46,10 @@ cryptographic
 cryptosystem
 datagram
 datarate
+deallocate
+deallocated
 deallocating
+deallocation
 decrypt
 decrypted
 dependant
@@ -124,6 +127,7 @@ pre
 preallocate
 preallocated
 preallocates
+preallocation
 preprocessor
 QoS
 QosPolicyCount


### PR DESCRIPTION
Documenting the new PayloadPool on the RTPS layer:

- Add the IPayloadPool interface to the API-ref
- Add the IChangePool interface to the API-ref
- Describe the functionality of the pool
- Describe how the default implementation works
- Explain how to create endpoints with a custom pool
- Provide an example using a custom pool

**note**: Keeping it as draft as tests will fail until all implementations are in place in Fast DDS.