### PR TITLE
Correct PropertiesPolicyType formatting [10117]

### DIFF
--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -1316,11 +1316,13 @@
 
             <propertiesPolicy>
                 <!-- PROPERTIES_POLICY -->
-                <property>
-                    <name>Property1Name</name>
-                    <value>Property1Value</value>
-                    <propagate>false</propagate>
-                </property>
+                <properties>
+                    <property>
+                        <name>Property1Name</name>
+                        <value>Property1Value</value>
+                        <propagate>false</propagate>
+                    </property>
+                </properties>
             </propertiesPolicy>
 
             <allocation>

--- a/docs/fastdds/xml_configuration/common.rst
+++ b/docs/fastdds/xml_configuration/common.rst
@@ -85,7 +85,7 @@ PropertiesPolicyType
 ^^^^^^^^^^^^^^^^^^^^
 
 PropertiesPolicyType defines the ``<propertiesPolicy>`` element.
-It allows the user to define a set of generic properties.
+It allows the user to define a set of generic properties inside a ``<properties>`` element.
 It is useful at defining extended or custom configuration parameters.
 
 +-----------------+---------------------------------------------------------------------+-------------+----------------+


### PR DESCRIPTION
Fixes failing [nightly build](http://jenkins.eprosima.com:8080/job/nightly_fastdds-docs_master/499/), caused by an incorrect setting of the `PropertiesPolicyQoS` in the `XMLTester.xml` example code.

Signed-off-by: Ignacio Montesino <ignaciomontesino@eprosima.com>