### PR TITLE
Log refactor docs update [10224]

### DIFF
--- a/docs/fastdds/logging/disable_module.rst
+++ b/docs/fastdds/logging/disable_module.rst
@@ -14,7 +14,7 @@ However, it is possible to fully disable each macro (and therefore each verbosit
 
 * |logInfo| is fully disabled by either:
 
-    * Setting CMake option |LOG_NO_INFO| to ``ON`` (Default with ``CMAKE_BUILD_TYPE`` different than ``Debug``).
+    * Setting CMake option |LOG_NO_INFO| to ``ON`` (default with ``CMAKE_BUILD_TYPE`` other than ``Debug``).
     * Defining macro |LOG_NO_INFO| to ``ON``
 
 * |logWarning| is fully disabled by either:
@@ -32,9 +32,8 @@ the compiler to optimize the call out.
 This is done so that all the debugging messages present on the library are optimized out at build time if not building
 for debugging purposes, thus preventing them to impact performance.
 
-``INTERNAL_DEBUG`` CMake option activates log macros compilation, so the arguments of the macros are compiled and
-executed.
-But it does not activate the log messages (it does not force log to write the messages in the macros).
+``INTERNAL_DEBUG`` CMake option activates log macros compilation, so the arguments of the macros are compiled.
+However it does not activate the log messages, i.e. the messages is not written in the log queue.
 
 .. warning::
 

--- a/docs/fastdds/logging/disable_module.rst
+++ b/docs/fastdds/logging/disable_module.rst
@@ -14,8 +14,7 @@ However, it is possible to fully disable each macro (and therefore each verbosit
 
 * |logInfo| is fully disabled by either:
 
-    * Setting CMake option ``CMAKE_BUILD_TYPE`` to something other than ``Debug`` (``Release`` or ``RelWithDebInfo``).
-    * Setting CMake option |LOG_NO_INFO| to ``ON``.
+    * Setting CMake option |LOG_NO_INFO| to ``ON`` (Default with ``CMAKE_BUILD_TYPE`` different than ``Debug``).
     * Defining macro |LOG_NO_INFO| to ``ON``
 
 * |logWarning| is fully disabled by either:
@@ -30,10 +29,12 @@ However, it is possible to fully disable each macro (and therefore each verbosit
 
 Applying either of the previously described methods will set the macro to be empty at configuration time, thus allowing
 the compiler to optimize the call out.
-|logInfo| is a special case worth mentioning; |logInfo| is only active is ``CMAKE_BUILD_TYPE`` is set to ``Debug``, or
-if ``INTERNAL_DEBUG`` is set to ``ON``.
 This is done so that all the debugging messages present on the library are optimized out at build time if not building
 for debugging purposes, thus preventing them to impact performance.
+
+``INTERNAL_DEBUG`` CMake option activates log macros compilation, so the arguments of the macros are compiled and
+executed.
+But it does not activate the log messages (it does not force log to write the messages in the macros).
 
 .. warning::
 

--- a/docs/fastdds/logging/disable_module.rst
+++ b/docs/fastdds/logging/disable_module.rst
@@ -15,17 +15,17 @@ However, it is possible to fully disable each macro (and therefore each verbosit
 * |logInfo| is fully disabled by either:
 
     * Setting CMake option |LOG_NO_INFO| to ``ON`` (default with ``CMAKE_BUILD_TYPE`` other than ``Debug``).
-    * Defining macro |LOG_NO_INFO| to ``ON``
+    * Defining macro |LOG_NO_INFO| to ``ON``.
 
 * |logWarning| is fully disabled by either:
 
     * Setting CMake option |LOG_NO_WARNING| to ``ON``.
-    * Defining macro |LOG_NO_WARNING| to ``ON``
+    * Defining macro |LOG_NO_WARNING| to ``ON``.
 
 * |logError| is fully disabled by either:
 
     * Setting CMake option |LOG_NO_ERROR| to ``ON``.
-    * Defining macro |LOG_NO_ERROR| to ``ON``
+    * Defining macro |LOG_NO_ERROR| to ``ON``.
 
 Applying either of the previously described methods will set the macro to be empty at configuration time, thus allowing
 the compiler to optimize the call out.
@@ -33,7 +33,7 @@ This is done so that all the debugging messages present on the library are optim
 for debugging purposes, thus preventing them to impact performance.
 
 ``INTERNAL_DEBUG`` CMake option activates log macros compilation, so the arguments of the macros are compiled.
-However it does not activate the log messages, i.e. the messages is not written in the log queue.
+However it does not activate the log messages, i.e. the messages are not written in the log queue.
 
 .. warning::
 

--- a/docs/fastdds/logging/logging_configuration.rst
+++ b/docs/fastdds/logging/logging_configuration.rst
@@ -94,7 +94,7 @@ respectively.
 .. warning::
 
     Setting any of the CMake options ``LOG_NO_INFO``, ``LOG_NO_WARNING`` or ``LOG_NO_ERROR`` to ``ON``
-    will disable completely this verbosity level.
+    will completely disable the corresponding verbosity level.
     ``LOG_NO_INFO`` is set to ``ON`` as default value if not in ``Debug`` mode.
 
 

--- a/docs/fastdds/logging/logging_configuration.rst
+++ b/docs/fastdds/logging/logging_configuration.rst
@@ -91,6 +91,12 @@ respectively.
     :end-before: //!--
     :dedent: 4
 
+.. warning::
+
+    Setting any of the CMake options ``LOG_NO_INFO``, ``LOG_NO_WARNING`` or ``LOG_NO_ERROR`` to ``ON``
+    will disable completely this verbosity level.
+    ``LOG_NO_INFO`` is set to ``ON`` as default value if not in ``Debug`` mode.
+
 
 .. _dds_layer_log_message:
 

--- a/docs/fastdds/logging/logging_messages.rst
+++ b/docs/fastdds/logging/logging_messages.rst
@@ -26,6 +26,7 @@ plus some meta information depending on the module's configuration (see :ref:`dd
 
 .. warning::
 
-    Note that |logInfo| is deactivated  when compiled with ``CMAKE_BUILD_TYPE`` other than ``Debug``. For more
-    information about how to enable and disable each individual logging macro, please refer to
+    Note that each message level is deactivated when CMake options ``LOG_NO_INFO``, ``LOG_NO_WARNING`` or
+    ``LOG_NO_ERROR`` are set to ``ON`` respectively.
+    For more information about how to enable and disable each individual logging macro, please refer to
     :ref:`dds_layer_log_disable`.

--- a/docs/installation/configuration/cmake_options.rst
+++ b/docs/installation/configuration/cmake_options.rst
@@ -81,12 +81,6 @@ dependency on other options.
           for more information on *Fast DDS* SHM transport.
         - ``ON`` ``OFF``
         - ``ON``
-    *   - :class:`LOG_CONSUMER_DEFAULT`
-        - Selects the default log consumer for the logging module. ``AUTO`` has the same behavior as ``STDOUT``. |br|
-          For more information, please refer to :ref:`Log consumers <dds_layer_log_consumer>`.
-        - ``AUTO`` ``STDOUT`` |br|
-          ``STDOUTERR``
-        - ``AUTO``
     *   - :class:`COMPILE_EXAMPLES`
         - Builds the *Fast DDS* examples. It is set to ``ON`` if :class:`EPROSIMA_BUILD` is ``ON`` and |br|
           :class:`EPROSIMA_INSTALLER` is ``OFF``. These examples can be found in the
@@ -117,14 +111,6 @@ dependency on other options.
           more information on *Fast DDS* real-time configuration.
         - ``ON`` ``OFF``
         - ``OFF``
-    *   - :class:`INTERNAL_DEBUG`
-        - Activates |Log::Kind::Info| debug messages (See :ref:`dds_layer_log_intro`). |br|
-          For this option to have any effect, i.e. to print the information messages,  |br|
-          *Fast DDS* must be debug built. This is done by setting the :class:`CMAKE_BUILD_TYPE` |br|
-          option to `Debug`. Moreover, :class:`INTERNAL_DEBUG` is set to ``ON`` if |br|
-          :class:`EPROSIMA_BUILD` is ``ON``.
-        - ``ON`` ``OFF``
-        - ``OFF``
     *   - :class:`SQLITE3_SUPPORT`
         - Builds the |SQLITE3_PLUGIN|, which enables the |TRANSIENT_DURABILITY_QOS-api| |br|
           and |PERSISTENT_DURABILITY_QOS-api| options for the :ref:`durabilitykind` |br|
@@ -132,6 +118,45 @@ dependency on other options.
         - ``ON`` ``OFF``
         - ``ON``
 
+Log options
+-----------
+*Fast DDS* uses its own configurable **Log module**  with different verbosity levels.
+Please, refer to :ref:`dds_layer_log_intro` section for more information.
+
+This module can be configured using *Fast DDS* CMake arguments regarding the following options.
+
+.. list-table::
+    :header-rows: 1
+
+    *   - Option
+        - Description
+        - Possible values
+        - Default
+    *   - :class:`LOG_CONSUMER_DEFAULT`
+        - Selects the default log consumer for the logging module. ``AUTO`` has the same behavior as ``STDOUT``. |br|
+          For more information, please refer to :ref:`Log consumers <dds_layer_log_consumer>`.
+        - ``AUTO`` ``STDOUT`` |br|
+          ``STDOUTERR``
+        - ``AUTO``
+    *   - :class:`LOG_NO_INFO`
+        - Deactivates Info Log level. |br|
+          If *Fast DDS* is built in debug mode, the default value will be ``OFF``.
+        - ``ON`` ``OFF``
+        - ``ON``
+    *   - :class:`LOG_NO_WARNING`
+        - Deactivates Warning Log level.
+        - ``ON`` ``OFF``
+        - ``OFF``
+    *   - :class:`LOG_NO_ERROR`
+        - Deactivates Error Log level.
+        - ``ON`` ``OFF``
+        - ``OFF``
+    *   - :class:`INTERNAL_DEBUG`
+        - Activates compilation of log messages (See :ref:`dds_layer_log_disable`). |br|
+          Moreover, :class:`INTERNAL_DEBUG` is set to ``ON`` if |br|
+          :class:`EPROSIMA_BUILD` is ``ON``.
+        - ``ON`` ``OFF``
+        - ``OFF``
 
 Third-party libraries options
 -----------------------------

--- a/docs/installation/configuration/cmake_options.rst
+++ b/docs/installation/configuration/cmake_options.rst
@@ -119,7 +119,8 @@ dependency on other options.
         - ``ON``
 
 Log options
------------
+^^^^^^^^^^^
+
 *Fast DDS* uses its own configurable **Log module**  with different verbosity levels.
 Please, refer to :ref:`dds_layer_log_intro` section for more information.
 
@@ -133,7 +134,8 @@ This module can be configured using *Fast DDS* CMake arguments regarding the fol
         - Possible values
         - Default
     *   - :class:`LOG_CONSUMER_DEFAULT`
-        - Selects the default log consumer for the logging module. ``AUTO`` has the same behavior as ``STDOUT``. |br|
+        - Selects the default log consumer for the logging module. |br|
+          ``AUTO`` has the same behavior as ``STDOUT``. |br|
           For more information, please refer to :ref:`Log consumers <dds_layer_log_consumer>`.
         - ``AUTO`` ``STDOUT`` |br|
           ``STDOUTERR``
@@ -159,7 +161,7 @@ This module can be configured using *Fast DDS* CMake arguments regarding the fol
         - ``OFF``
 
 Third-party libraries options
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 *Fast DDS* relies on the `eProsima FastCDR <https://github.com/eProsima/Fast-CDR>`_ library for serialization
 mechanisms.
@@ -235,7 +237,7 @@ These libraries can also be configured using *Fast DDS* CMake options.
     (:class:`CMAKE_SYSTEM_NAME`) is Android.
 
 Test options
-------------
+^^^^^^^^^^^^
 
 *eProsima Fast DDS* comes with a full set of tests for continuous integration.
 The types of tests are: unit tests, black-box tests, performance tests, profiling tests, and


### PR DESCRIPTION
Log refactor information added in Logging module.

CMake arguments separate in other subtitle *Log options*

Signed-off-by: jparisu <javierparis@eprosima.com>