### PR TITLE
Added a warning note for small segments sizes

### DIFF
--- a/docs/fastdds/transport/shared_memory/shared_memory.rst
+++ b/docs/fastdds/transport/shared_memory/shared_memory.rst
@@ -168,7 +168,7 @@ such as Wireshark.
 
 .. warning::
 
-    Setting a ``<segment_size>`` close to or smaller than the size or your data creates a high risk of data loss, as the
+    Setting a ``<segment_size>`` close to or smaller than the data size creates a high risk of data loss, as the
     write operation will overwrite the buffer during a single send operation.
 
 .. _transport_sharedMemory_enabling:

--- a/docs/fastdds/transport/shared_memory/shared_memory.rst
+++ b/docs/fastdds/transport/shared_memory/shared_memory.rst
@@ -168,7 +168,7 @@ such as Wireshark.
 
 .. warning::
 
-    Setting a ``<segment_size>`` close to or smaller than the data size creates a high risk of data loss, as the
+    Setting a ``<segment_size>`` close to or smaller than the data size poses a high risk of data loss, since the
     write operation will overwrite the buffer during a single send operation.
 
 .. _transport_sharedMemory_enabling:

--- a/docs/fastdds/transport/shared_memory/shared_memory.rst
+++ b/docs/fastdds/transport/shared_memory/shared_memory.rst
@@ -166,6 +166,10 @@ such as Wireshark.
    The *kind* value for a SharedMemTransportDescriptor is given by the value
    ``eprosima::fastrtps::rtps::LOCATOR_KIND_SHM``
 
+.. warning::
+
+    Setting a ``<segment_size>`` close to or smaller than the size or your data creates a high risk of data loss, as the
+    write operation will overwrite the buffer during a single send operation.
 
 .. _transport_sharedMemory_enabling:
 


### PR DESCRIPTION
Added warning to prevent buffer ovewrite in a single message. Related to eProsima/Fast-DDS#1666. 

Signed-off-by: Ignacio Montesino <ignaciomontesino@eprosima.com>