### PR TITLE
[20722] Update docs to force unlimited ResourceLimits if lower or equal to zero

### DIFF
--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -1217,14 +1217,14 @@ List of QoS Policy data members:
   can manage across all the
   instances associated with it.
   In other words, it represents the maximum samples that the middleware can store for a DataReader or DataWriter.
-  **Value 0 means infinite resources.**
+  **Value less or equal to 0 means infinite resources.**
 * |ResourceLimitsQosPolicy::max_instances-api|: Controls the maximum number of instances that a DataWriter or
   DataReader can manage.
-  **Value 0 means infinite resources.**
+  **Value less or equal to 0 means infinite resources.**
 * |ResourceLimitsQosPolicy::max_samples_per_instance-api|: Controls the maximum number of samples within an instance
   that the DataWriter or
   DataReader can manage.
-  **Value 0 means infinite resources.**
+  **Value less or equal to 0 means infinite resources.**
 * |ResourceLimitsQosPolicy::allocated_samples-api|: States the number of samples that will be allocated on
   initialization.
 * |ResourceLimitsQosPolicy::extra_samples-api|: States the number of extra samples that will be allocated on

--- a/docs/fastdds/xml_configuration/common.rst
+++ b/docs/fastdds/xml_configuration/common.rst
@@ -304,17 +304,17 @@ Please refer to :ref:`ResourceLimitsQosPolicy` for further information on Resour
 +--------------------------------+-----------------------------------------------------------+---------------+---------+
 | Name                           | Description                                               | Values        | Default |
 +================================+===========================================================+===============+=========+
-| ``<max_samples>``              | It must verify that:                                      | ``uint32_t``  | 5000    |
+| ``<max_samples>``              | It must verify that:                                      | ``int32_t``   | 5000    |
 |                                | ``<max_samples>`` `>=` ``<max_samples_per_instance>``.    |               |         |
 +--------------------------------+-----------------------------------------------------------+---------------+---------+
-| ``<max_instances>``            | It defines the maximum number of instances.               | ``uint32_t``  | 10      |
+| ``<max_instances>``            | It defines the maximum number of instances.               | ``int32_t``   | 10      |
 +--------------------------------+-----------------------------------------------------------+---------------+---------+
-| ``<max_samples_per_instance>`` | It must verify that: :ref:`HistoryQos <hQos>`             | ``uint32_t``  | 400     |
+| ``<max_samples_per_instance>`` | It must verify that: :ref:`HistoryQos <hQos>`             | ``int32_t``   | 400     |
 |                                | ``<depth>`` `<=` ``<max_samples_per_instance>``.          |               |         |
 +--------------------------------+-----------------------------------------------------------+---------------+---------+
-| ``<allocated_samples>``        | It controls the maximum number of samples to be stored.   | ``uint32_t``  | 100     |
+| ``<allocated_samples>``        | It controls the maximum number of samples to be stored.   | ``int32_t``   | 100     |
 +--------------------------------+-----------------------------------------------------------+---------------+---------+
-| ``<extra_samples>``            | The number of extra samples to allocate on the pool.      | ``uint32_t``  | 1       |
+| ``<extra_samples>``            | The number of extra samples to allocate on the pool.      | ``int32_t``   | 1       |
 +--------------------------------+-----------------------------------------------------------+---------------+---------+
 
 .. _ThreadSettingsType:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR updates documentation regarding resource limits (see attached PR)
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 2.13.x 2.10.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->

Related implementation PR:
* eProsima/Fast-DDS#4617

## Contributor Checklist

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- **N/A** Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
