### PR TITLE
[#23561] Fix compilation in Windows platforms

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -1544,7 +1544,8 @@ void dds_discovery_examples()
     }
 
     {
-        DomainParticipant* client_or_server;
+        DomainParticipant* client_or_server =
+                DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
         //CONF_SERVER_ADD_SERVERS
         // Get existing QoS for the server or client
         DomainParticipantQos client_or_server_qos;
@@ -2985,7 +2986,8 @@ void dds_dataWriter_examples()
         // Create a DataWriter with default QoS and a custom TopicQos.
         // The value DATAWRITER_QOS_USE_TOPIC_QOS is used to denote the default QoS
         // and to override the TopicQos.
-        Topic* topic;
+        Topic* topic =
+                participant->create_topic("", "", TOPIC_QOS_DEFAULT);
         DataWriter* data_writer_with_default_qos_and_custom_topic_qos =
                 publisher->create_datawriter(topic, DATAWRITER_QOS_USE_TOPIC_QOS);
         if (nullptr == data_writer_with_default_qos_and_custom_topic_qos)
@@ -3865,7 +3867,8 @@ void dds_dataReader_examples()
         // Create a DataReader with default QoS and a custom TopicQos.
         // The value DATAREADER_QOS_USE_TOPIC_QOS is used to denote the default QoS
         // and to override the TopicQos.
-        Topic* topic;
+        Topic* topic =
+                participant->create_topic("", "", TOPIC_QOS_DEFAULT);
         DataReader* data_reader_with_default_qos_and_custom_topic_qos =
                 subscriber->create_datareader(topic, DATAREADER_QOS_USE_TOPIC_QOS);
         if (nullptr == data_reader_with_default_qos_and_custom_topic_qos)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -476,6 +476,9 @@ autodoc_default_options = {
 }
 
 plantuml = "/usr/bin/plantuml -Djava.awt.headless=true "
+if sys.platform.startswith("win"):
+    plantuml = "C:\\ProgramData\\chocolatey\\bin\\plantuml.exe -Djava.awt.headless=true "
+
 plantuml_output_format = "svg"
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This PR adds: 
- Default path to ```chocolatey plantuml.exe``` for **Windows platforms** 
- **Initialize** three variables in ```DDSCodeTester.cpp``` to solve three **warnings treated as errors**.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
