### PR TITLE
[#23543] Added cmake-arg 'SHARED_LIBRARY_SUFFIX'

### DIFF
--- a/docs/installation/configuration/cmake_options.rst
+++ b/docs/installation/configuration/cmake_options.rst
@@ -363,9 +363,10 @@ The *Fast DDS Python-Binding* CMake options are shown below, together with their
         - Default
     *   - :class:`SHARED_LIBRARY_SUFFIX`
         - Defines the file suffix (extension) used for shared libraries in the build process.
-          For example ".dll" on Windows or ".so" on Linux. The default value for this argument is
-          an empty string, setting the default extension for each platform (Linux and macOS: ".so",
-          Windows: ".dll"). The "dot" in the extension does not have to be included in the CMake argument.
+          For Windows OS, the extension can not be modified, always use the cmake default value.
+          The default value for this argument is an empty string,
+          setting the default extension for each platform (Linux and macOS: ".so").
+          The "dot" in the extension does not have to be included in the CMake argument.
 
-        - ``Valid string (e.g.: "dll", "so", ...)``
+        - ``Valid string (e.g.: "dylib", "so", ...)``
         - ``"""``


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR adds a new CMake argument: **'SHARED_LIBRARY_SUFFIX'** in "7.5. Python-Bindings", to define the file suffix (extension) used for shared libraries in the build process

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.3.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [ ] Code snippets related to the added documentation have been provided.
- [ ] Documentation tests pass locally.
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
