### PR TITLE
Adding documentation for properties of persistence mode

### DIFF
--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -7329,7 +7329,7 @@ void dds_persistence_examples()
     drqos.durability().kind = TRANSIENT_DURABILITY_QOS;
     drqos.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
     drqos.properties().properties().emplace_back("dds.persistence.guid",
-            "72.65.61.64.65.72.5f.70.65.72.73.5f|67.75.69.65");
+            "77.72.69.74.65.72.5f.71.65.72.73.5f|67.75.69.65");
     drqos.properties().properties().emplace_back("dds.persistence.sqlite3.filename", "dr_persistence_service.db");
     DataReader* reader = subscriber->create_datareader(topic, drqos);
     //!--

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -7254,7 +7254,7 @@ void dds_persistence_examples()
     // Configure persistence service plugin for DomainParticipant
     DomainParticipantQos pqos;
     pqos.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
-    pqos.properties().properties().emplace_back("dds.persistence.sqlite3.filename", "persistence.db");
+    pqos.properties().properties().emplace_back("dds.persistence.sqlite3.filename", "part_persistence_service.db");
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(0, pqos);
 
     /********************************************************************************************************
@@ -7311,16 +7311,26 @@ void dds_persistence_examples()
 
     // Configure DataWriter's durability and persistence GUID so it can use the persistence service
     DataWriterQos dwqos = DATAWRITER_QOS_DEFAULT;
+    dwqos.history().kind = KEEP_LAST_HISTORY_QOS;
+    dwqos.history().depth = 20;
+    dwqos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     dwqos.durability().kind = TRANSIENT_DURABILITY_QOS;
+    dwqos.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
     dwqos.properties().properties().emplace_back("dds.persistence.guid",
-            "77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64");
+            "77.72.69.74.65.72.5f.71.65.72.73.5f|67.75.69.64");
+    dwqos.properties().properties().emplace_back("dds.persistence.sqlite3.filename", "dw_persistence_service.db");
     DataWriter* writer = publisher->create_datawriter(topic, dwqos);
 
     // Configure DataReaders's durability and persistence GUID so it can use the persistence service
     DataReaderQos drqos = DATAREADER_QOS_DEFAULT;
+    drqos.history().kind = KEEP_LAST_HISTORY_QOS;
+    drqos.history().depth = 20;
+    drqos.reliability().kind = RELIABLE_RELIABILITY_QOS;
     drqos.durability().kind = TRANSIENT_DURABILITY_QOS;
+    drqos.properties().properties().emplace_back("dds.persistence.plugin", "builtin.SQLITE3");
     drqos.properties().properties().emplace_back("dds.persistence.guid",
-            "72.65.61.64.65.72.5f.70.65.72.73.5f|67.75.69.64");
+            "72.65.61.64.65.72.5f.70.65.72.73.5f|67.75.69.65");
+    drqos.properties().properties().emplace_back("dds.persistence.sqlite3.filename", "dr_persistence_service.db");
     DataReader* reader = subscriber->create_datareader(topic, drqos);
     //!--
 }

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3538,7 +3538,7 @@
 <dds xmlns="http://www.eprosima.com">
     <profiles>
 -->
-        <!-- DomainParticipant configuration -->
+<!-- DomainParticipant configuration -->
         <participant profile_name="persistence_service_participant">
             <rtps>
                 <propertiesPolicy>
@@ -3548,10 +3548,10 @@
                             <name>dds.persistence.plugin</name>
                             <value>builtin.SQLITE3</value>
                         </property>
-                        <!-- Database file name -->
+                        <!-- Filename will only be used if endpoint does not define its own -->
                         <property>
                             <name>dds.persistence.sqlite3.filename</name>
-                            <value>persistence_service.db</value>
+                            <value>part_persistence_service.db</value>
                         </property>
                     </properties>
                 </propertiesPolicy>
@@ -3561,14 +3561,12 @@
         <!-- DataWriter configuration -->
         <data_writer profile_name="persistence_service_data_writer">
             <topic>
-                <!-- History depth should be large enough to guarantee correct retransmissions -->
                 <historyQos>
                     <kind>KEEP_LAST</kind>
                     <depth>20</depth>
                 </historyQos>
             </topic>
             <qos>
-                <!-- RELIABLE reliability is required to allow a full recovery -->
                 <reliability>
                     <kind>RELIABLE</kind>
                 </reliability>
@@ -3579,26 +3577,32 @@
             </qos>
             <propertiesPolicy>
                 <properties>
+                    <property>
+                        <name>dds.persistence.plugin</name>
+                        <value>builtin.SQLITE3</value>
+                    </property>
                     <!-- Persistence GUID -->
                     <property>
                         <name>dds.persistence.guid</name>
-                        <value>77.72.69.74.65.72.5f.70.65.72.73.5f|67.75.69.64</value>
+                        <value>77.72.69.74.65.72.5f.71.65.72.73.5f|67.75.69.64</value>
+                    </property>
+                    <property>
+                        <name>dds.persistence.sqlite3.filename</name>
+                        <value>dw_persistence_service.db</value>
                     </property>
                 </properties>
             </propertiesPolicy>
+
         </data_writer>
 
-        <!-- DataReader configuration -->
         <data_reader profile_name="persistence_service_data_reader">
             <topic>
-                <!-- History depth should be large enough to guarantee correct retransmissions -->
                 <historyQos>
                     <kind>KEEP_LAST</kind>
                     <depth>20</depth>
                 </historyQos>
             </topic>
             <qos>
-                <!-- RELIABLE reliability is required to allow a full recovery -->
                 <reliability>
                     <kind>RELIABLE</kind>
                 </reliability>
@@ -3609,10 +3613,18 @@
             </qos>
             <propertiesPolicy>
                 <properties>
+                    <property>
+                        <name>dds.persistence.plugin</name>
+                        <value>builtin.SQLITE3</value>
+                    </property>
                     <!-- Persistence GUID -->
                     <property>
                         <name>dds.persistence.guid</name>
-                        <value>72.65.61.64.65.72.5f.70.65.72.73.5f|67.75.69.64</value>
+                        <value>72.65.61.64.65.72.5f.70.65.72.73.5f|67.75.69.65</value>
+                    </property>
+                    <property>
+                        <name>dds.persistence.sqlite3.filename</name>
+                        <value>dr_persistence_service.db</value>
                     </property>
                 </properties>
             </propertiesPolicy>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3560,7 +3560,18 @@
 
         <!-- DataWriter configuration -->
         <data_writer profile_name="persistence_service_data_writer">
+            <topic>
+                <!-- History depth should be large enough to guarantee correct retransmissions -->
+                <historyQos>
+                    <kind>KEEP_LAST</kind>
+                    <depth>20</depth>
+                </historyQos>
+            </topic>
             <qos>
+                <!-- RELIABLE reliability is required to allow a full recovery -->
+                <reliability>
+                    <kind>RELIABLE</kind>
+                </reliability>
                 <!-- Set durability to TRANSIENT_DURABILITY_QOS -->
                 <durability>
                     <kind>TRANSIENT</kind>
@@ -3579,7 +3590,18 @@
 
         <!-- DataReader configuration -->
         <data_reader profile_name="persistence_service_data_reader">
+            <topic>
+                <!-- History depth should be large enough to guarantee correct retransmissions -->
+                <historyQos>
+                    <kind>KEEP_LAST</kind>
+                    <depth>20</depth>
+                </historyQos>
+            </topic>
             <qos>
+                <!-- RELIABLE reliability is required to allow a full recovery -->
+                <reliability>
+                    <kind>RELIABLE</kind>
+                </reliability>
                 <!-- Set durability to TRANSIENT_DURABILITY_QOS -->
                 <durability>
                     <kind>TRANSIENT</kind>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3595,6 +3595,7 @@
 
         </data_writer>
 
+        <!-- DataReader configuration -->
         <data_reader profile_name="persistence_service_data_reader">
             <topic>
                 <historyQos>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3592,7 +3592,6 @@
                     </property>
                 </properties>
             </propertiesPolicy>
-
         </data_writer>
 
         <!-- DataReader configuration -->

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3538,7 +3538,7 @@
 <dds xmlns="http://www.eprosima.com">
     <profiles>
 -->
-<!-- DomainParticipant configuration -->
+        <!-- DomainParticipant configuration -->
         <participant profile_name="persistence_service_participant">
             <rtps>
                 <propertiesPolicy>
@@ -3620,7 +3620,7 @@
                     <!-- Persistence GUID -->
                     <property>
                         <name>dds.persistence.guid</name>
-                        <value>72.65.61.64.65.72.5f.70.65.72.73.5f|67.75.69.65</value>
+                        <value>77.72.69.74.65.72.5f.71.65.72.73.5f|67.75.69.65</value>
                     </property>
                     <property>
                         <name>dds.persistence.sqlite3.filename</name>

--- a/code/XMLTester.xml
+++ b/code/XMLTester.xml
@@ -3577,6 +3577,7 @@
             </propertiesPolicy>
         </data_writer>
 
+        <!-- DataReader configuration -->
         <data_reader profile_name="persistence_service_data_reader">
             <qos>
                 <!-- Set durability to TRANSIENT_DURABILITY_QOS -->

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -131,7 +131,7 @@ from C++ and using *eProsima Fast DDS* XML profile files (see :ref:`xml_profiles
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-96, 98-99
+       :lines: 2-4, 6-61, 63-97, 99-100
 
 .. note::
     For instructions on how to create DomainParticipants, DataReaders, and DataWriters, please refer to

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -29,6 +29,14 @@ in which they were when the shutdown occurred.
     This means that they will resume operation where they left, but they will not have the previous information, since
     that was already notified to the application.
 
+.. note::
+    It may be necessary to configure the history depth of the DataWriter and DataReader to a value large enough to
+    guarantee that all the changes stored in the database are enough for a correct recovery of the application
+
+.. note::
+    RELIABLE reliability is required to allow a full recovery, since it guarantees that all the changes are stored in
+    the database and that they will be available for the DataWriter/DataReader upon restart.
+
 
 .. _persistence_service_conf:
 
@@ -87,13 +95,12 @@ These properties are summarized in the following table:
        Default value: ``persistence.db``
 
 .. note::
-    To avoid undesired delays caused by concurrent access to the SQLite3 database, it is advisable to specify a
-    different database file for each DataWriter and DataReader.
+    To avoid undesired delays caused by concurrent access to the SQLite3 database, it is strongly recommended to
+    specify a different database file for each DataWriter and DataReader.
 
 .. important::
     The plugin set in the PropertyPolicyQos of DomainParticipant only applies if that of the
     DataWriter/DataReader does not exist or is invalid.
-
 
 .. _persistence_example:
 

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -92,7 +92,7 @@ These properties are summarized in the following table:
 
 .. important::
     The plugin set in the PropertyPolicyQos of DomainParticipant only applies if that of the
-    DataWriter/DataReader does no exist or is invalid.
+    DataWriter/DataReader does not exist or is invalid.
 
 
 .. _persistence_example:

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -131,7 +131,7 @@ from C++ and using *eProsima Fast DDS* XML profile files (see :ref:`xml_profiles
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-97, 99-100
+       :lines: 2-4, 6-96, 98-99
 
 .. note::
     For instructions on how to create DomainParticipants, DataReaders, and DataWriters, please refer to

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -131,7 +131,7 @@ from C++ and using *eProsima Fast DDS* XML profile files (see :ref:`xml_profiles
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-96
+       :lines: 2-4, 6-61, 63-96, 98-99
 
 .. note::
     For instructions on how to create DomainParticipants, DataReaders, and DataWriters, please refer to

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -50,7 +50,8 @@ or DataReader) |PropertyPolicyQos|.
 * For the :ref:`persistence_service` to have any effect, the |DurabilityQosPolicyKind-api| needs to be set to
   |TRANSIENT_DURABILITY_QOS-api| or |PERSISTENT_DURABILITY_QOS-api|.
 
-* A persistence identifier (|Guid_t-api|) must be set for the entity using the property ``dds.persistence.guid``.
+* A persistence identifier (|Guid_t-api|) must be set on the endpoint (|DataWriter-api| or
+  |DataReader-api|) using the property ``dds.persistence.guid``.
   This identifier is used to load the appropriate data from the database, and also to synchronize DataWriter and
   DataReader between restarts.
   The GUID consists of 16 bytes separated into two groups:
@@ -64,8 +65,9 @@ or DataReader) |PropertyPolicyQos|.
   For selecting an appropriate GUID for the DataReader and DataWriter, please refer to
   `RTPS standard <https://www.omg.org/spec/DDSI-RTPS/2.2/PDF>`_ (section *9.3.1 The Globally Unique Identifier (GUID)*).
 
-  If no ``dds.persistence.guid`` is specified,
-  the durability behavior will fallback to |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
+  This property must be defined at the endpoint level.
+  If absent, the durability behaviour falls back to |TRANSIENT_LOCAL_DURABILITY_QOS-api|,
+  regardless of any plugin configuration.
 
 * A persistence plugin must be configured for managing the database using property ``dds.persistence.plugin`` (see
   :ref:`persistence_sqlite3_builtin_plugin`):
@@ -77,9 +79,9 @@ PERSISTENCE:SQLITE3 built-in plugin
 
 This plugin provides persistence through a local database file using *SQLite3* API.
 To activate the plugin, ``dds.persistence.plugin`` property must be added to the PropertyPolicyQos of the
-DomainParticipant, DataWriter, or DataReader with value ``builtin.SQLITE3``.
-Furthermore, ``dds.persistence.sqlite3.filename`` property must be added to the entities PropertyPolicyQos,
-specifying the database file name.
+DataWriter or DataReader with value ``builtin.SQLITE3``.
+Optionally, ``dds.persistence.sqlite3.filename`` property can be added to the entity's PropertyPolicyQos
+to specify the database file name; if omitted, the default value ``persistence.db`` is used.
 These properties are summarized in the following table:
 
 .. list-table:: **Persistence::SQLITE3 configuration properties**
@@ -99,8 +101,15 @@ These properties are summarized in the following table:
     specify a different database file for each DataWriter and DataReader.
 
 .. important::
-    The plugin set in the PropertyPolicyQos of DomainParticipant only applies if that of the
-    DataWriter/DataReader does not exist or is invalid.
+    ``dds.persistence.plugin`` and ``dds.persistence.sqlite3.filename`` are resolved as a pair:
+    if ``dds.persistence.plugin`` is not set at the endpoint (DataWriter/DataReader) level,
+    both properties are taken from the |DomainParticipant-api| instead; a
+    ``dds.persistence.sqlite3.filename`` defined at the endpoint without a
+    ``dds.persistence.plugin`` at the same level is ignored.
+    ``dds.persistence.guid`` must be defined at the endpoint level; if absent, the behaviour
+    falls back to |TRANSIENT_LOCAL_DURABILITY_QOS-api|, regardless of any plugin configuration.
+    It is strongly recommended to set all three properties directly on the endpoint for
+    predictable behaviour.
 
 .. _persistence_example:
 

--- a/docs/fastdds/persistence/persistence.rst
+++ b/docs/fastdds/persistence/persistence.rst
@@ -31,10 +31,10 @@ in which they were when the shutdown occurred.
 
 .. note::
     It may be necessary to configure the history depth of the DataWriter and DataReader to a value large enough to
-    guarantee that all the changes stored in the database are enough for a correct recovery of the application
+    guarantee that all the changes stored in the database are enough for a correct recovery of the application.
 
 .. note::
-    RELIABLE reliability is required to allow a full recovery, since it guarantees that all the changes are stored in
+    |RELIABLE_RELIABILITY_QOS-api| reliability is required to allow a full recovery, since it guarantees that all the changes are stored in
     the database and that they will be available for the DataWriter/DataReader upon restart.
 
 
@@ -131,7 +131,7 @@ from C++ and using *eProsima Fast DDS* XML profile files (see :ref:`xml_profiles
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-64
+       :lines: 2-4, 6-61, 63-96
 
 .. note::
     For instructions on how to create DomainParticipants, DataReaders, and DataWriters, please refer to

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -58,4 +58,4 @@ required QoS settings for a correct operation of the service (see :ref:`persiste
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-97, 99-100
+       :lines: 2-4, 6-96, 98-99

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -25,7 +25,7 @@ When using the :ref:`persistence_service`, the following properties must be set 
   It can be set on the |DomainParticipant-api|, a |DataWriter-api|, or a |DataReader-api|.
   If this property is absent at the endpoint level, both ``dds.persistence.plugin`` and
   ``dds.persistence.sqlite3.filename`` are taken from the |DomainParticipant-api| instead.
-  Setting it at the endpoint level is recommended.
+  Setting it at the endpoint level is strongly recommended.
   At the moment, the only valid value is ``builtin.SQLITE3``
   (see :ref:`persistence_sqlite3_builtin_plugin`).
 
@@ -58,4 +58,4 @@ required QoS settings for a correct operation of the service (see :ref:`persiste
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-64
+       :lines: 2-4, 6-61, 63-96

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -6,19 +6,32 @@
 Persistence Service Settings
 ----------------------------
 
-When using the :ref:`persistence_service`, specific properties must be set on the
+When using the :ref:`persistence_service`, the following properties must be set on the
 |DomainParticipant-api|, |DataWriter-api|, or |DataReader-api| via their |PropertyPolicyQos|.
+
+.. important::
+
+   It is strongly recommended to define all three properties at the endpoint
+   (|DataWriter-api| or |DataReader-api|) level for predictable behaviour.
+   ``dds.persistence.plugin`` and ``dds.persistence.sqlite3.filename`` are resolved
+   as a pair from the first level where ``dds.persistence.plugin`` is present
+   (endpoint first, then |DomainParticipant-api|); a ``dds.persistence.sqlite3.filename``
+   defined at the endpoint level without a ``dds.persistence.plugin`` at the same level
+   is ignored.
+   ``dds.persistence.guid`` must be defined at the endpoint level; if absent, the behaviour
+   falls back to |TRANSIENT_LOCAL_DURABILITY_QOS-api|, regardless of any plugin configuration.
 
 * Property ``dds.persistence.plugin`` selects the persistence plugin to use.
   It can be set on the |DomainParticipant-api|, a |DataWriter-api|, or a |DataReader-api|.
-  When set on the |DomainParticipant-api|, it acts as the fallback for any DataWriter or
-  DataReader that does not specify its own plugin.
+  If this property is absent at the endpoint level, both ``dds.persistence.plugin`` and
+  ``dds.persistence.sqlite3.filename`` are taken from the |DomainParticipant-api| instead.
+  Setting it at the endpoint level is recommended.
   At the moment, the only valid value is ``builtin.SQLITE3``
   (see :ref:`persistence_sqlite3_builtin_plugin`).
 
 * Property ``dds.persistence.sqlite3.filename`` specifies the path to the SQLite3 database
   file used for persistent storage when the SQLite3 plugin is used.
-  The default value is ``persistence.db``.
+  This property is optional; the default value is ``persistence.db``.
   To avoid undesired delays caused by concurrent access, it is advisable to use a different
   database file for each DataWriter and DataReader.
 
@@ -26,8 +39,9 @@ When using the :ref:`persistence_service`, specific properties must be set on th
   DataWriter or DataReader.
   This identifier is used to load the appropriate data from the database and to synchronize
   the entity between restarts.
-  If this property is not set, the durability behaviour falls back to
-  |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
+  This property must be defined at the endpoint level.
+  If absent, the durability behaviour falls back to |TRANSIENT_LOCAL_DURABILITY_QOS-api|,
+  regardless of any plugin configuration.
 
 The following example shows how to configure the persistence service properties along with the
 required QoS settings for a correct operation of the service (see :ref:`persistence_example`).

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -58,4 +58,4 @@ required QoS settings for a correct operation of the service (see :ref:`persiste
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-96, 98-99
+       :lines: 2-4, 6-61, 63-97, 99-100

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -6,5 +6,41 @@
 Persistence Service Settings
 ----------------------------
 
-.. warning::
-    This section is still under work.
+When using the :ref:`persistence_service`, specific properties must be set on the
+|DomainParticipant-api|, |DataWriter-api|, or |DataReader-api| via their |PropertyPolicyQos|.
+
+* Property ``dds.persistence.plugin`` selects the persistence plugin to use.
+  It can be set on the |DomainParticipant-api|, a |DataWriter-api|, or a |DataReader-api|.
+  When set on the |DomainParticipant-api|, it acts as the fallback for any DataWriter or
+  DataReader that does not specify its own plugin.
+  At the moment, the only valid value is ``builtin.SQLITE3``
+  (see :ref:`persistence_sqlite3_builtin_plugin`).
+
+* Property ``dds.persistence.sqlite3.filename`` specifies the path to the SQLite3 database
+  file used for persistent storage when the SQLite3 plugin is used.
+  The default value is ``persistence.db``.
+  To avoid undesired delays caused by concurrent access, it is advisable to use a different
+  database file for each DataWriter and DataReader.
+
+* Property ``dds.persistence.guid`` sets the persistence identifier (|Guid_t-api|) for a
+  DataWriter or DataReader.
+  This identifier is used to load the appropriate data from the database and to synchronize
+  the entity between restarts.
+  If this property is not set, the durability behaviour falls back to
+  |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
+
+The following example shows how to configure the persistence service properties:
+
+.. tab-set-code::
+
+    .. literalinclude:: /../code/DDSCodeTester.cpp
+       :language: c++
+       :start-after: //CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE
+       :end-before: //!--
+       :dedent: 4
+
+    .. literalinclude:: /../code/XMLTester.xml
+       :language: xml
+       :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
+       :end-before: <!--><-->
+       :lines: 2-4, 6-61, 63-64

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -29,7 +29,8 @@ When using the :ref:`persistence_service`, specific properties must be set on th
   If this property is not set, the durability behaviour falls back to
   |TRANSIENT_LOCAL_DURABILITY_QOS-api|.
 
-The following example shows how to configure the persistence service properties:
+The following example shows how to configure the persistence service properties along with the
+required QoS settings for a correct operation of the service (see :ref:`persistence_example`).
 
 .. tab-set-code::
 

--- a/docs/fastdds/property_policies/persistence.rst
+++ b/docs/fastdds/property_policies/persistence.rst
@@ -58,4 +58,4 @@ required QoS settings for a correct operation of the service (see :ref:`persiste
        :language: xml
        :start-after: <!-->CONF-PERSISTENCE-SERVICE-SQLITE3-EXAMPLE<-->
        :end-before: <!--><-->
-       :lines: 2-4, 6-61, 63-96
+       :lines: 2-4, 6-61, 63-96, 98-99


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Persistence properties section was "Still under work", this PR just populates the file with the information already described in section 7.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->

@Mergifyio backport 3.4.x 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- [_N/A_] The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
