### PR TITLE
Clean v2.6.0 Release notes

### DIFF
--- a/docs/notes/previous_versions/v3.6.0.rst
+++ b/docs/notes/previous_versions/v3.6.0.rst
@@ -7,12 +7,12 @@ This release includes the following **security fixes**:
 
 This release includes the following **improvements**:
 
-1. Update `RELEASE_SUPPORT.md` with `2.14.6` (#6313)
-2. Add should_endpoints_match callback in `DomainParticipant` and `RTPSParticipant` (#6336)
-3. Add context to type support operations (#6320)
+1. Update `RELEASE_SUPPORT.md` with `2.14.6`
+2. Add should_endpoints_match callback in `DomainParticipant` and `RTPSParticipant`
+3. Add context to type support operations
 
 This release includes the following **fixes**:
 
-1. Change default python branch from 'main' to 'master' (#6325)
-2. Fix ABI break in `register_service_type` (#6327)
-3. Fix `TinyXML2` library resolution in tests (#6329)
+1. Change default python branch from 'main' to 'master'
+2. Fix ABI break in `register_service_type`
+3. Fix `TinyXML2` library resolution in tests

--- a/docs/notes/previous_versions/v3.6.0.rst
+++ b/docs/notes/previous_versions/v3.6.0.rst
@@ -7,12 +7,12 @@ This release includes the following **security fixes**:
 
 This release includes the following **improvements**:
 
-1. Update `RELEASE_SUPPORT.md` with `2.14.6`
-2. Add should_endpoints_match callback in `DomainParticipant` and `RTPSParticipant`
+1. Update ``RELEASE_SUPPORT.md`` with ``2.14.6``
+2. Add should_endpoints_match callback in ``DomainParticipant`` and ``RTPSParticipant``
 3. Add context to type support operations
 
 This release includes the following **fixes**:
 
-1. Change default python branch from 'main' to 'master'
-2. Fix ABI break in `register_service_type`
-3. Fix `TinyXML2` library resolution in tests
+1. Change default python branch from ``main`` to ``master``
+2. Fix ABI break in ``register_service_type``
+3. Fix ``TinyXML2`` library resolution in tests


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR deletes the GitHub PR number of the release notes

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.5.x 3.4.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
