### PR TITLE
[23705] Update DataWriter blocking behavior & Unique Network flows section

### DIFF
--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -470,16 +470,9 @@ The HistoryQos must be set consistently with the :ref:`resourcelimitsqospolicy`,
   |ResourceLimitsQosPolicy::max_samples-api|).
 * In the case of the :ref:`reliabilityqospolicy` |ReliabilityQosPolicyKind-api| being set to
   |RELIABLE_RELIABILITY_QOS-api| and the :ref:`historyqospolicy` |HistoryQosPolicy::kind-api| being set to
-  |KEEP_ALL_HISTORY_QOS-api|, when the resource limits are reached, the behavior of the service is depends on the
-  :ref:`durabilityqospolicy`:
-
-  * If the :ref:`durabilityqospolicy` |DurabilityQosPolicy::kind-api| is configured as |VOLATILE_DURABILITY_QOS-api|,
-    the DataWriter |DataWriter::write-api| call will discard the oldest sample in the history.
-    Note that the removed sample may belong to different :ref:`instances<dds_layer_topic_instances>` than the newly
-    written one.
-  * If the :ref:`durabilityqospolicy` |DurabilityQosPolicy::kind-api| is configured as
-    |TRANSIENT_LOCAL_DURABILITY_QOS-api| or |TRANSIENT_DURABILITY_QOS-api|, the DataWriter |DataWriter::write-api| call
-    will be blocked until the history has space for the new sample.
+  |KEEP_ALL_HISTORY_QOS-api|, when the resource limits are reached the DataWriter |DataWriter::write-api| call will
+  block (up to |ReliabilityQosPolicy::max_blocking_time-api|) until the oldest sample has been acknowledged by all readers and can be removed.
+  If |ReliabilityQosPolicy::max_blocking_time-api| is reached, the |DataWriter::write-api| call will return with a timeout error.
 
 Example
 """""""

--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -471,8 +471,10 @@ The HistoryQos must be set consistently with the :ref:`resourcelimitsqospolicy`,
 * In the case of the :ref:`reliabilityqospolicy` |ReliabilityQosPolicyKind-api| being set to
   |RELIABLE_RELIABILITY_QOS-api| and the :ref:`historyqospolicy` |HistoryQosPolicy::kind-api| being set to
   |KEEP_ALL_HISTORY_QOS-api|, when the resource limits are reached the DataWriter |DataWriter::write-api| call will
-  block (up to |ReliabilityQosPolicy::max_blocking_time-api|) until the oldest sample has been acknowledged by all readers and can be removed.
-  If |ReliabilityQosPolicy::max_blocking_time-api| is reached, the |DataWriter::write-api| call will return with a timeout error.
+  block (up to |ReliabilityQosPolicy::max_blocking_time-api|) until the oldest sample has been acknowledged by all
+  readers and can be removed.
+  If |ReliabilityQosPolicy::max_blocking_time-api| is reached, the |DataWriter::write-api| call will return with a
+  timeout error.
 
 Example
 """""""

--- a/docs/fastdds/property_policies/non_consolidated_qos.rst
+++ b/docs/fastdds/property_policies/non_consolidated_qos.rst
@@ -69,12 +69,32 @@ See :ref:`tuning-heartbeat-period` for more details.
     * It is inconsistent to enable the ``pull mode`` and also set the |WriterTimes::heartbeat_period-api| to
       |c_TimeInfinite-api|.
 
+.. _unique_network_flows_qos_policy:
 
 Unique network flows QoS Policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. warning::
-    This section is still under work.
+This QoS Policy allows a |DataReader-api| to be created with a unique network flow, i.e. listening on a
+port that is not shared with any other endpoint of the same |DomainParticipant-api|.
+This is useful when the application needs to apply specific Network QoS parameters (for example, through 3GPP/5QI
+configuration on the underlying networking equipment) to the traffic of a particular topic.
+
+The feature is enabled by adding the property ``"fastdds.unique_network_flows"`` to the
+:ref:`propertypolicyqos` of the |DataReader-api|.
+
+.. list-table::
+   :header-rows: 1
+   :align: left
+
+   * - PropertyPolicyQos name
+     - PropertyPolicyQos value
+     - Default value
+   * - ``"fastdds.unique_network_flows"``
+     - ``""``
+     - Not set
+
+For a complete description of network flows in *Fast DDS*, the APIs used to inspect them, and a usage example,
+see :ref:`use-case-unique-flows`.
 
 .. _property_policies_statistics:
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR updates the DataWriter `write()` call blocking behavior documentation to its real implementation, as it does not depend on the Durability QoS. 

It also adds the missing section of Unique Network Flows to the Non-Consolidated QoS.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.5.x 3.4.x 3.2.x 2.14.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
