### PR TITLE
[24365] Add all security plugins

### DIFF
--- a/code/CodeTester.cpp
+++ b/code/CodeTester.cpp
@@ -323,6 +323,10 @@ bool permissions_test(
     part_attr.properties.properties().emplace_back(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         permissions_file);
+
+    // Activate Crypto:AES-GCM-GMAC plugin (all three security plugins must be configured together)
+    part_attr.properties.properties().emplace_back("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC");
     RTPSParticipant* participant = RTPSDomain::createParticipant(0, part_attr);
     if (participant != nullptr)
     {

--- a/code/DDSCodeTester.cpp
+++ b/code/DDSCodeTester.cpp
@@ -8126,6 +8126,10 @@ bool dds_permissions_test(
         "dds.sec.access.builtin.Access-Permissions.permissions",
         permissions_file);
 
+    // Activate Crypto:AES-GCM-GMAC plugin (all three security plugins must be configured together)
+    pqos.properties().properties().emplace_back("dds.sec.crypto.plugin",
+            "builtin.AES-GCM-GMAC");
+
     DomainParticipant* domain_participant =
             DomainParticipantFactory::get_instance()->create_participant(1, pqos);
     if (nullptr != domain_participant)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
This PR allows compatibility with https://github.com/eProsima/Fast-DDS/pull/6386. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
- [x] Documentation tests pass locally.
- _N/A_: The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] CI passes without warnings or errors.
