### PR TITLE
[24416] Document limits in duration values

### DIFF
--- a/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
+++ b/docs/fastdds/dds_layer/core/policy/standardQosPolicies.rst
@@ -1062,6 +1062,9 @@ List of QoS Policy data members:
      :raw-html:`<br />`
      It cannot be changed on enabled entities.
 
+.. note::
+     It is inconsistent to set an infinite |ReliabilityQosPolicy::max_blocking_time-api|.
+
 .. important::
     Setting this QoS Policy to |BEST_EFFORT_RELIABILITY_QOS-api| affects to the :ref:`durabilityqospolicy`, making the
     endpoints behave as |VOLATILE_DURABILITY_QOS-api|.

--- a/docs/fastdds/xml_configuration/common.rst
+++ b/docs/fastdds/xml_configuration/common.rst
@@ -225,6 +225,11 @@ An infinite value can be specified by using the values :cpp:concept:`DURATION_IN
     - ``uint32_t``
     - 0
 
+.. note::
+
+    It is inconsistent to specify a negative value for the ``<sec>`` element, or
+    a ``<nanosec>`` value greater than or equal to 1 second (i.e., 1,000,000,000 nanoseconds).
+
 **Example**
 
 .. literalinclude:: /../code/XMLTester.xml


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If implementation PR is still pending, please add `implementation-pending` label.
-->

## Description
<!--
    Describe changes in detail.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Document 1 second limit in nanoseconds member of duration values.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x 2.14.x 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

<!-- In case the changes are related to an implementation PR, please uncomment the next lines. -->
<!--
Related implementation PR:
* eProsima/Fast-DDS#(PR)
-->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS docs developers must also refer to the internal Redmine task. -->
- [x] Code snippets related to the added documentation have been provided.
    - I verified that all the examples are within the limits. 
- [x] Documentation tests pass locally.
- _N/A_: The ``Pro`` version badge has been added if the documented feature is exclusive to Fast DDS Pro.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] CI passes without warnings or errors.
